### PR TITLE
feat: Webページテンプレートの改善と学習ガイド追加

### DIFF
--- a/src/app/note/webpage-temp/[id]/page.tsx
+++ b/src/app/note/webpage-temp/[id]/page.tsx
@@ -96,6 +96,16 @@ export default async function TemplateDetailPage(props: PageProps) {
               <span>必要に応じて、テキストや画像、色などをカスタマイズしてご使用ください。</span>
             </li>
           </ol>
+          <div className="mt-6 p-4 bg-blue-900/30 border border-blue-600 rounded">
+            <p className="text-blue-400 mb-2">📚 初めての方へ</p>
+            <p className="text-gray-300 text-sm">
+              HTMLやCSSが初めての方は、
+              <Link href="/note/webpage-temp/guide" className="text-blue-400 hover:text-blue-300 underline">
+                初心者向けWeb制作学習ガイド
+              </Link>
+              をご覧ください。実際に手を動かしながら学べる詳しい手順を解説しています。
+            </p>
+          </div>
         </div>
 
         {/* 注意事項 */}

--- a/src/app/note/webpage-temp/guide/page.tsx
+++ b/src/app/note/webpage-temp/guide/page.tsx
@@ -1,0 +1,358 @@
+import Link from 'next/link'
+
+export default function WebDevelopmentGuidePage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto py-10 px-4">
+        {/* ナビゲーション */}
+        <nav className="mb-6">
+          <Link href="/note/webpage-temp" className="text-blue-600 hover:text-blue-700 hover:underline">
+            ← テンプレート一覧へ戻る
+          </Link>
+        </nav>
+
+        {/* ヘッダー */}
+        <header className="mb-10">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            初心者エンジニアのためのWeb制作学習ガイド
+          </h1>
+          <p className="text-lg text-gray-600">
+            テンプレートを使って、実際にWebサイトを作りながら学んでいきましょう。
+            コピー&ペーストから始めて、少しずつカスタマイズしていく方法を解説します。
+          </p>
+        </header>
+
+        {/* Step 1 */}
+        <section className="mb-12 bg-white rounded-lg shadow-md p-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+            <span className="bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mr-3">1</span>
+            まずは動かしてみよう
+          </h2>
+          
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-xl font-semibold mb-3">準備するもの</h3>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>パソコン（Windows/Mac/Linux どれでもOK）</li>
+                <li>テキストエディタ（メモ帳でもOK、VSCodeがおすすめ）</li>
+                <li>Webブラウザ（Chrome、Firefox、Safari など）</li>
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">手順</h3>
+              <ol className="space-y-4">
+                <li className="pl-6">
+                  <strong className="block mb-2">1. フォルダを作成</strong>
+                  <p className="text-gray-700">デスクトップに「my-website」という名前のフォルダを作ります。</p>
+                  <div className="bg-gray-100 p-3 rounded mt-2 font-mono text-sm">
+                    Windows: デスクトップで右クリック → 新規作成 → フォルダー<br/>
+                    Mac: デスクトップで右クリック → 新規フォルダ
+                  </div>
+                </li>
+                
+                <li className="pl-6">
+                  <strong className="block mb-2">2. HTMLファイルを作成</strong>
+                  <p className="text-gray-700">「my-website」フォルダの中に「index.html」というファイルを作ります。</p>
+                  <div className="bg-gray-100 p-3 rounded mt-2">
+                    <p className="text-sm mb-2">テキストエディタを開いて、新規ファイルを作成し、「index.html」という名前で保存します。</p>
+                  </div>
+                </li>
+
+                <li className="pl-6">
+                  <strong className="block mb-2">3. HTMLコードをコピー</strong>
+                  <p className="text-gray-700">テンプレートページから、HTMLタブのコードを全てコピーして、index.htmlに貼り付けます。</p>
+                  <div className="bg-blue-50 p-3 rounded mt-2 text-sm">
+                    💡 Ctrl+A（全選択）→ Ctrl+C（コピー）→ Ctrl+V（貼り付け）が便利です
+                  </div>
+                </li>
+
+                <li className="pl-6">
+                  <strong className="block mb-2">4. CSSファイルを作成</strong>
+                  <p className="text-gray-700">同じフォルダに「style.css」というファイルを作成し、CSSコードをコピーして貼り付けます。</p>
+                </li>
+
+                <li className="pl-6">
+                  <strong className="block mb-2">5. JavaScriptファイルを作成</strong>
+                  <p className="text-gray-700">「script.js」というファイルを作成し、JavaScriptコードをコピーして貼り付けます。</p>
+                </li>
+
+                <li className="pl-6">
+                  <strong className="block mb-2">6. HTMLファイルを修正</strong>
+                  <p className="text-gray-700">index.htmlの&lt;head&gt;タグ内に以下を追加：</p>
+                  <pre className="bg-gray-900 text-gray-100 p-3 rounded mt-2 overflow-x-auto">
+{`<link rel="stylesheet" href="style.css">`}
+                  </pre>
+                  <p className="text-gray-700 mt-2">&lt;/body&gt;タグの直前に以下を追加：</p>
+                  <pre className="bg-gray-900 text-gray-100 p-3 rounded mt-2 overflow-x-auto">
+{`<script src="script.js"></script>`}
+                  </pre>
+                </li>
+
+                <li className="pl-6">
+                  <strong className="block mb-2">7. ブラウザで確認</strong>
+                  <p className="text-gray-700">index.htmlファイルをブラウザにドラッグ&ドロップして表示を確認します。</p>
+                  <div className="bg-green-50 p-3 rounded mt-2 text-sm">
+                    ✅ おめでとうございます！あなたの最初のWebサイトが動きました！
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 2 */}
+        <section className="mb-12 bg-white rounded-lg shadow-md p-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+            <span className="bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mr-3">2</span>
+            カスタマイズしてみよう - 色を変える
+          </h2>
+          
+          <div className="space-y-6">
+            <p className="text-gray-700">
+              次は、サイトの色を変えてみましょう。CSSファイルを編集することで、簡単に見た目を変更できます。
+            </p>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">背景色を変える</h3>
+              <p className="text-gray-700 mb-3">style.cssファイルを開いて、bodyの背景色を変更してみましょう。</p>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`body {
+    background: #f0f8ff;  /* 薄い青色に変更 */
+}`}
+              </pre>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">文字色を変える</h3>
+              <p className="text-gray-700 mb-3">見出しの色を変更してみましょう。</p>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`h1 {
+    color: #ff6b6b;  /* 赤っぽい色に変更 */
+}`}
+              </pre>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">ボタンの色を変える</h3>
+              <p className="text-gray-700 mb-3">ボタンの背景色とホバー時の色を変更します。</p>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`.btn-primary {
+    background: #4CAF50;  /* 緑色に変更 */
+}
+
+.btn-primary:hover {
+    background: #45a049;  /* 少し暗い緑色 */
+}`}
+              </pre>
+            </div>
+
+            <div className="bg-blue-50 p-4 rounded">
+              <h4 className="font-semibold mb-2">💡 色の指定方法</h4>
+              <ul className="space-y-1 text-sm">
+                <li>• 色名: red, blue, green など</li>
+                <li>• HEX: #ff0000（赤）、#00ff00（緑）、#0000ff（青）</li>
+                <li>• RGB: rgb(255, 0, 0)（赤）</li>
+                <li>• <a href="https://htmlcolorcodes.com/" className="text-blue-600 underline" target="_blank">色コード参考サイト</a></li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 3 */}
+        <section className="mb-12 bg-white rounded-lg shadow-md p-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+            <span className="bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mr-3">3</span>
+            テキストと画像を変更する
+          </h2>
+          
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-xl font-semibold mb-3">テキストの変更</h3>
+              <p className="text-gray-700 mb-3">index.htmlファイルを開いて、テキストを自分のコンテンツに変更します。</p>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`<!-- 変更前 -->
+<h1>Modern Cafe</h1>
+<p>こだわりのコーヒーと心地よい空間</p>
+
+<!-- 変更後 -->
+<h1>My Awesome Site</h1>
+<p>私の素晴らしいWebサイトへようこそ！</p>`}
+              </pre>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">画像の変更</h3>
+              <p className="text-gray-700 mb-3">画像を自分の画像に変更する方法：</p>
+              <ol className="list-decimal pl-6 space-y-2">
+                <li>「images」フォルダを作成</li>
+                <li>使いたい画像をそのフォルダに入れる（例: hero.jpg）</li>
+                <li>HTMLのimg要素のsrc属性を変更</li>
+              </ol>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto mt-3">
+{`<!-- 変更前 -->
+<img src="https://example.com/image.jpg" alt="画像">
+
+<!-- 変更後 -->
+<img src="images/hero.jpg" alt="私の画像">`}
+              </pre>
+            </div>
+
+            <div className="bg-yellow-50 p-4 rounded">
+              <h4 className="font-semibold mb-2">⚠️ 画像使用の注意点</h4>
+              <ul className="space-y-1 text-sm">
+                <li>• 画像サイズは適切に（大きすぎると表示が遅くなります）</li>
+                <li>• 無料画像サイト: <a href="https://unsplash.com/" className="text-blue-600 underline" target="_blank">Unsplash</a>、<a href="https://www.pexels.com/" className="text-blue-600 underline" target="_blank">Pexels</a></li>
+                <li>• alt属性は必ず設定（アクセシビリティのため）</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 4 */}
+        <section className="mb-12 bg-white rounded-lg shadow-md p-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+            <span className="bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mr-3">4</span>
+            レイアウトを調整する
+          </h2>
+          
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-xl font-semibold mb-3">余白（マージン・パディング）を調整</h3>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`.section {
+    padding: 100px 0;  /* 上下の余白を増やす */
+    margin: 0 auto;    /* 中央寄せ */
+}`}
+              </pre>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">フォントサイズを変更</h3>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`h1 {
+    font-size: 48px;  /* 大きくする */
+}
+
+p {
+    font-size: 18px;  /* 読みやすいサイズに */
+    line-height: 1.8; /* 行間を広げる */
+}`}
+              </pre>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold mb-3">レスポンシブ対応（スマホ表示）</h3>
+              <pre className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
+{`@media (max-width: 768px) {
+    h1 {
+        font-size: 32px;  /* スマホでは小さく */
+    }
+    
+    .container {
+        padding: 0 20px;   /* 左右の余白を確保 */
+    }
+}`}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        {/* Next Steps */}
+        <section className="mb-12 bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg shadow-md p-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4">
+            🚀 次のステップ
+          </h2>
+          
+          <div className="space-y-4">
+            <div className="bg-white p-4 rounded">
+              <h3 className="font-semibold mb-2">もっと学びたい方へ</h3>
+              <ul className="space-y-2 text-gray-700">
+                <li>📚 <strong>HTML/CSS基礎</strong>: <a href="https://developer.mozilla.org/ja/docs/Learn/HTML" className="text-blue-600 underline" target="_blank">MDN Web Docs</a></li>
+                <li>🎨 <strong>デザイン</strong>: <a href="https://www.figma.com/" className="text-blue-600 underline" target="_blank">Figma</a>でデザインを作ってみる</li>
+                <li>⚡ <strong>JavaScript</strong>: インタラクティブな機能を追加</li>
+                <li>📱 <strong>レスポンシブデザイン</strong>: スマホ対応を極める</li>
+              </ul>
+            </div>
+
+            <div className="bg-white p-4 rounded">
+              <h3 className="font-semibold mb-2">実践的なプロジェクト</h3>
+              <ul className="space-y-2 text-gray-700">
+                <li>• 自己紹介サイトを作る</li>
+                <li>• 好きなお店のサイトを模写する</li>
+                <li>• ポートフォリオサイトを作る</li>
+                <li>• 友達や家族のサイトを作ってあげる</li>
+              </ul>
+            </div>
+
+            <div className="bg-white p-4 rounded">
+              <h3 className="font-semibold mb-2">公開する方法</h3>
+              <ul className="space-y-2 text-gray-700">
+                <li>🌐 <strong>GitHub Pages</strong>: 無料で簡単に公開</li>
+                <li>⚡ <strong>Netlify</strong>: ドラッグ&ドロップで公開</li>
+                <li>🔥 <strong>Vercel</strong>: Next.jsなどのフレームワークに最適</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Tips */}
+        <section className="mb-12 bg-white rounded-lg shadow-md p-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4">
+            💡 開発のコツ
+          </h2>
+          
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="bg-blue-50 p-4 rounded">
+              <h3 className="font-semibold mb-2">開発ツール</h3>
+              <ul className="text-sm space-y-1">
+                <li>• <strong>VSCode</strong>: 無料の高機能エディタ</li>
+                <li>• <strong>Chrome DevTools</strong>: F12で開発者ツール</li>
+                <li>• <strong>Live Server</strong>: 自動更新で開発効率UP</li>
+              </ul>
+            </div>
+
+            <div className="bg-green-50 p-4 rounded">
+              <h3 className="font-semibold mb-2">よくあるミス</h3>
+              <ul className="text-sm space-y-1">
+                <li>• タグの閉じ忘れ（&lt;/div&gt;など）</li>
+                <li>• セミコロンの忘れ（CSS）</li>
+                <li>• ファイルパスの間違い</li>
+                <li>• 全角スペースの混入</li>
+              </ul>
+            </div>
+
+            <div className="bg-yellow-50 p-4 rounded">
+              <h3 className="font-semibold mb-2">デバッグ方法</h3>
+              <ul className="text-sm space-y-1">
+                <li>• コンソールでエラーを確認</li>
+                <li>• 一つずつ変更して確認</li>
+                <li>• コメントアウトで原因を特定</li>
+              </ul>
+            </div>
+
+            <div className="bg-purple-50 p-4 rounded">
+              <h3 className="font-semibold mb-2">学習のコツ</h3>
+              <ul className="text-sm space-y-1">
+                <li>• 毎日少しずつでも触る</li>
+                <li>• 完璧を求めすぎない</li>
+                <li>• 他の人のコードを読む</li>
+                <li>• 作ったものを公開する</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <footer className="text-center text-gray-600 py-8">
+          <p>このガイドが役に立ったら、ぜひ友達にもシェアしてください！</p>
+          <p className="mt-2">
+            <Link href="/note/webpage-temp" className="text-blue-600 hover:underline">
+              テンプレート一覧に戻る
+            </Link>
+          </p>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/templates/data/cafe-minimal.ts
+++ b/src/lib/templates/data/cafe-minimal.ts
@@ -1,0 +1,478 @@
+import { WebTemplate, TEMPLATE_CATEGORIES } from '../types'
+
+export const cafeMinimalTemplate: WebTemplate = {
+  id: 'cafe-minimal',
+  title: 'カフェ - ミニマル',
+  category: TEMPLATE_CATEGORIES.CAFE,
+  description: 'シンプルで洗練されたミニマルデザインのカフェテンプレート',
+  thumbnail: '/template-images/cafe-minimal.jpg',
+  features: [
+    'ミニマルデザイン',
+    '高速表示',
+    'アクセシビリティ対応',
+    'モノトーン配色'
+  ],
+  tags: ['カフェ', 'ミニマル', 'シンプル', 'モノトーン'],
+  code: {
+    html: `<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MINIMAL CAFE - Less is More</title>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav-brand">MINIMAL</div>
+        <button class="nav-toggle" aria-label="メニュー">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <ul class="nav-menu">
+            <li><a href="#concept">Concept</a></li>
+            <li><a href="#menu">Menu</a></li>
+            <li><a href="#gallery">Gallery</a></li>
+            <li><a href="#info">Info</a></li>
+        </ul>
+    </nav>
+
+    <header class="hero">
+        <div class="hero-bg">
+            <img src="https://images.unsplash.com/photo-1501339847302-ac426a4a7cbb?w=1920&h=1080&fit=crop" alt="ミニマルカフェ">
+        </div>
+        <div class="hero-content">
+            <h1 class="hero-title">MINIMAL<br>CAFE</h1>
+            <p class="hero-tagline">Less is More</p>
+        </div>
+    </header>
+
+    <section id="concept" class="concept">
+        <div class="container">
+            <h2 class="section-title">Concept</h2>
+            <div class="concept-text">
+                <p>余計なものを削ぎ落とし、</p>
+                <p>本質だけを追求したカフェ。</p>
+                <p>シンプルな空間で、</p>
+                <p>コーヒーの味わいに集中する。</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="menu" class="menu">
+        <div class="container">
+            <h2 class="section-title">Menu</h2>
+            <div class="menu-grid">
+                <div class="menu-item">
+                    <img src="https://images.unsplash.com/photo-1514432324607-a09d9b4aefdd?w=600&h=400&fit=crop" alt="エスプレッソ">
+                    <h3>Espresso</h3>
+                    <p class="price">¥380</p>
+                </div>
+                <div class="menu-item">
+                    <img src="https://images.unsplash.com/photo-1485808191679-5f86510681a2?w=600&h=400&fit=crop" alt="ドリップコーヒー">
+                    <h3>Drip Coffee</h3>
+                    <p class="price">¥450</p>
+                </div>
+                <div class="menu-item">
+                    <img src="https://images.unsplash.com/photo-1504630083234-14187a9df0f5?w=600&h=400&fit=crop" alt="カフェラテ">
+                    <h3>Cafe Latte</h3>
+                    <p class="price">¥520</p>
+                </div>
+                <div class="menu-item">
+                    <img src="https://images.unsplash.com/photo-1497636577773-f1231844b336?w=600&h=400&fit=crop" alt="コールドブリュー">
+                    <h3>Cold Brew</h3>
+                    <p class="price">¥480</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="gallery" class="gallery">
+        <h2 class="section-title">Gallery</h2>
+        <div class="gallery-grid">
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1493857671505-72967e2e2760?w=800&h=600&fit=crop" alt="店内1">
+            </div>
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1453614512568-c4024d13c247?w=800&h=600&fit=crop" alt="店内2">
+            </div>
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1445116572660-236099ec97a0?w=800&h=600&fit=crop" alt="店内3">
+            </div>
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1509042239860-f550ce710b93?w=800&h=600&fit=crop" alt="コーヒー">
+            </div>
+        </div>
+    </section>
+
+    <section id="info" class="info">
+        <div class="container">
+            <h2 class="section-title">Information</h2>
+            <div class="info-grid">
+                <div class="info-item">
+                    <h3>Hours</h3>
+                    <p>月-金: 7:00 - 20:00</p>
+                    <p>土日: 8:00 - 19:00</p>
+                </div>
+                <div class="info-item">
+                    <h3>Location</h3>
+                    <p>東京都目黒区中目黒1-2-3</p>
+                    <p>中目黒駅から徒歩3分</p>
+                </div>
+                <div class="info-item">
+                    <h3>Contact</h3>
+                    <p>03-1234-5678</p>
+                    <p>info@minimalcafe.jp</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <p>&copy; 2025 MINIMAL CAFE</p>
+    </footer>
+</body>
+</html>`,
+    css: `* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    line-height: 1.6;
+    color: #222;
+    background: #fff;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Navigation */
+.nav {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(10px);
+    padding: 1.5rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 1000;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+}
+
+.nav-brand {
+    font-size: 1.5rem;
+    font-weight: 300;
+    letter-spacing: 3px;
+}
+
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    gap: 4px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 5px;
+}
+
+.nav-toggle span {
+    width: 25px;
+    height: 2px;
+    background: #222;
+    transition: 0.3s;
+}
+
+.nav-menu {
+    display: flex;
+    list-style: none;
+    gap: 3rem;
+}
+
+.nav-menu a {
+    text-decoration: none;
+    color: #222;
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+    transition: opacity 0.3s;
+}
+
+.nav-menu a:hover {
+    opacity: 0.6;
+}
+
+/* Hero */
+.hero {
+    height: 100vh;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-bg img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.7);
+}
+
+.hero-content {
+    text-align: center;
+    color: #fff;
+}
+
+.hero-title {
+    font-size: 5rem;
+    font-weight: 100;
+    letter-spacing: 10px;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+}
+
+.hero-tagline {
+    font-size: 1.2rem;
+    letter-spacing: 5px;
+    opacity: 0.9;
+}
+
+/* Sections */
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+}
+
+section {
+    padding: 6rem 0;
+}
+
+.section-title {
+    text-align: center;
+    font-size: 2.5rem;
+    font-weight: 100;
+    letter-spacing: 5px;
+    margin-bottom: 4rem;
+}
+
+/* Concept */
+.concept {
+    background: #fafafa;
+}
+
+.concept-text {
+    text-align: center;
+    font-size: 1.3rem;
+    line-height: 2.5;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+/* Menu */
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 3rem;
+}
+
+.menu-item {
+    text-align: center;
+}
+
+.menu-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    margin-bottom: 1rem;
+}
+
+.menu-item h3 {
+    font-size: 1.2rem;
+    font-weight: 300;
+    letter-spacing: 2px;
+    margin-bottom: 0.5rem;
+}
+
+.price {
+    font-size: 1.1rem;
+    color: #666;
+}
+
+/* Gallery */
+.gallery {
+    padding: 0;
+}
+
+.gallery .section-title {
+    padding: 4rem 0 2rem;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0;
+}
+
+.gallery-item {
+    overflow: hidden;
+    height: 400px;
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s;
+}
+
+.gallery-item:hover img {
+    transform: scale(1.1);
+}
+
+/* Info */
+.info {
+    background: #fafafa;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 3rem;
+    text-align: center;
+}
+
+.info-item h3 {
+    font-size: 1.2rem;
+    font-weight: 300;
+    letter-spacing: 2px;
+    margin-bottom: 1rem;
+}
+
+.info-item p {
+    color: #666;
+    margin-bottom: 0.5rem;
+}
+
+/* Footer */
+.footer {
+    background: #222;
+    color: #fff;
+    text-align: center;
+    padding: 2rem;
+    font-size: 0.9rem;
+    letter-spacing: 2px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .nav-toggle {
+        display: flex;
+    }
+    
+    .nav-menu {
+        position: fixed;
+        left: -100%;
+        top: 70px;
+        flex-direction: column;
+        background: white;
+        width: 100%;
+        text-align: center;
+        transition: 0.3s;
+        box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
+        padding: 2rem 0;
+    }
+    
+    .nav-menu.active {
+        left: 0;
+    }
+    
+    .hero-title {
+        font-size: 3rem;
+        letter-spacing: 5px;
+    }
+    
+    .hero-tagline {
+        font-size: 1rem;
+    }
+    
+    .gallery-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .gallery-item {
+        height: 250px;
+    }
+    
+    .menu-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .info-grid {
+        grid-template-columns: 1fr;
+    }
+}`,
+    js: `// モバイルメニュー
+const navToggle = document.querySelector('.nav-toggle');
+const navMenu = document.querySelector('.nav-menu');
+
+navToggle.addEventListener('click', () => {
+    navMenu.classList.toggle('active');
+    
+    // ハンバーガーアニメーション
+    const spans = navToggle.querySelectorAll('span');
+    if (navMenu.classList.contains('active')) {
+        spans[0].style.transform = 'rotate(45deg) translateY(8px)';
+        spans[1].style.opacity = '0';
+        spans[2].style.transform = 'rotate(-45deg) translateY(-8px)';
+    } else {
+        spans[0].style.transform = 'none';
+        spans[1].style.opacity = '1';
+        spans[2].style.transform = 'none';
+    }
+});
+
+// スムーズスクロール
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function (e) {
+        e.preventDefault();
+        navMenu.classList.remove('active');
+        
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+            const navHeight = document.querySelector('.nav').offsetHeight;
+            const targetPosition = target.offsetTop - navHeight;
+            window.scrollTo({
+                top: targetPosition,
+                behavior: 'smooth'
+            });
+        }
+    });
+});
+
+// スクロール時のナビゲーション背景
+window.addEventListener('scroll', () => {
+    const nav = document.querySelector('.nav');
+    if (window.scrollY > 100) {
+        nav.style.background = 'rgba(255, 255, 255, 1)';
+    } else {
+        nav.style.background = 'rgba(255, 255, 255, 0.98)';
+    }
+});`
+  }
+}

--- a/src/lib/templates/data/cafe-modern.ts
+++ b/src/lib/templates/data/cafe-modern.ts
@@ -37,6 +37,9 @@ export const cafeModernTemplate: WebTemplate = {
     </header>
 
     <section class="hero">
+        <div class="hero-image">
+            <img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1920&h=1080&fit=crop" alt="カフェの雰囲気">
+        </div>
         <div class="hero-content">
             <h1 class="hero-title">Modern Cafe</h1>
             <p class="hero-subtitle">こだわりのコーヒーと心地よい空間</p>
@@ -49,14 +52,17 @@ export const cafeModernTemplate: WebTemplate = {
             <h2 class="section-title">私たちのこだわり</h2>
             <div class="about-grid">
                 <div class="about-item">
+                    <img src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?w=400&h=300&fit=crop" alt="コーヒー豆">
                     <h3>厳選されたコーヒー豆</h3>
                     <p>世界各地から厳選した最高品質のコーヒー豆を使用しています。</p>
                 </div>
                 <div class="about-item">
+                    <img src="https://images.unsplash.com/photo-1554118811-1e0d58224f24?w=400&h=300&fit=crop" alt="カフェ内装">
                     <h3>心地よい空間</h3>
                     <p>ゆったりとした時間を過ごせる、こだわりの空間設計。</p>
                 </div>
                 <div class="about-item">
+                    <img src="https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=400&h=300&fit=crop" alt="季節のメニュー">
                     <h3>季節のメニュー</h3>
                     <p>旬の食材を使った、季節限定メニューをご用意しています。</p>
                 </div>
@@ -97,6 +103,15 @@ export const cafeModernTemplate: WebTemplate = {
                 <p>〒150-0001 東京都渋谷区神宮前1-2-3</p>
                 <p>営業時間: 8:00 - 21:00（L.O. 20:30）</p>
                 <p>定休日: 毎週水曜日</p>
+            </div>
+            <div class="video-container">
+                <iframe 
+                    src="https://www.youtube.com/embed/5qap5aO4i9A" 
+                    title="Lofi hip hop radio" 
+                    frameborder="0" 
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                    allowfullscreen>
+                </iframe>
             </div>
         </div>
     </section>
@@ -165,12 +180,34 @@ body {
 
 .hero {
     height: 100vh;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     color: white;
+    overflow: hidden;
+}
+
+.hero-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.4);
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
 }
 
 .hero-title {
@@ -233,11 +270,17 @@ body {
 
 .about-item {
     text-align: center;
-    padding: 2rem;
     background: white;
     border-radius: 10px;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
     transition: transform 0.3s;
+    overflow: hidden;
+}
+
+.about-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
 }
 
 .about-item:hover {
@@ -246,7 +289,12 @@ body {
 
 .about-item h3 {
     color: #8b7355;
-    margin-bottom: 1rem;
+    margin: 1.5rem 0 1rem;
+    padding: 0 2rem;
+}
+
+.about-item p {
+    padding: 0 2rem 2rem;
 }
 
 .menu-grid {
@@ -301,10 +349,42 @@ body {
     }
 }
 
+.video-container {
+    margin-top: 2rem;
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 @media (max-width: 768px) {
     .nav-menu {
+        position: fixed;
+        left: -100%;
+        top: 70px;
         flex-direction: column;
-        gap: 1rem;
+        background-color: white;
+        width: 100%;
+        text-align: center;
+        transition: 0.3s;
+        box-shadow: 0 10px 27px rgba(0,0,0,0.05);
+        padding: 2rem 0;
+    }
+    
+    .nav-menu.active {
+        left: 0;
+    }
+    
+    .nav-menu li {
+        margin: 1rem 0;
     }
     
     .hero-title {
@@ -313,6 +393,14 @@ body {
     
     .hero-subtitle {
         font-size: 1.2rem;
+    }
+    
+    .about-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .menu-grid {
+        grid-template-columns: 1fr;
     }
 }`,
     js: `// スムーズスクロール

--- a/src/lib/templates/data/restaurant-western.ts
+++ b/src/lib/templates/data/restaurant-western.ts
@@ -1,0 +1,793 @@
+import { WebTemplate, TEMPLATE_CATEGORIES } from '../types'
+
+export const restaurantWesternTemplate: WebTemplate = {
+  id: 'restaurant-western',
+  title: 'レストラン - 洋食',
+  category: TEMPLATE_CATEGORIES.RESTAURANT,
+  description: '高級感のある洋食レストラン向けWebサイトテンプレート',
+  thumbnail: '/template-images/restaurant-western.jpg',
+  features: [
+    'エレガントなデザイン',
+    'コース料理紹介',
+    'シェフ紹介',
+    'オンライン予約'
+  ],
+  tags: ['レストラン', '洋食', 'フレンチ', 'イタリアン'],
+  code: {
+    html: `<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Le Jardin - Fine Dining Restaurant</title>
+</head>
+<body>
+    <header class="header">
+        <div class="header-inner">
+            <h1 class="logo">Le Jardin</h1>
+            <nav class="navigation">
+                <ul>
+                    <li><a href="#home">Home</a></li>
+                    <li><a href="#concept">Concept</a></li>
+                    <li><a href="#menu">Menu</a></li>
+                    <li><a href="#chef">Chef</a></li>
+                    <li><a href="#info">Info</a></li>
+                    <li><a href="#reservation" class="reservation-link">Reservation</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section id="home" class="hero">
+        <div class="hero-image">
+            <img src="https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1920&h=1080&fit=crop" alt="Restaurant Interior">
+        </div>
+        <div class="hero-content">
+            <h2 class="hero-title">Le Jardin</h2>
+            <p class="hero-subtitle">A Symphony of Flavors</p>
+            <p class="hero-description">フランス料理の伝統と革新が融合する、特別な食体験</p>
+        </div>
+    </section>
+
+    <section id="concept" class="concept">
+        <div class="container">
+            <h2 class="section-title">Our Concept</h2>
+            <div class="concept-content">
+                <div class="concept-image">
+                    <img src="https://images.unsplash.com/photo-1559339352-11d035aa65de?w=600&h=800&fit=crop" alt="Chef at work">
+                </div>
+                <div class="concept-text">
+                    <h3>季節の恵みを、芸術へ</h3>
+                    <p>Le Jardinでは、厳選された季節の食材を使い、フランス料理の伝統技法に現代的なエッセンスを加えた料理をご提供しています。</p>
+                    <p>ソムリエが厳選したワインとのマリアージュで、忘れられない食体験をお約束します。</p>
+                    <p>落ち着いた空間で、大切な方との特別な時間をお過ごしください。</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="menu" class="menu">
+        <div class="container">
+            <h2 class="section-title">Course Menu</h2>
+            <div class="menu-intro">
+                <p>旬の食材を使用したコース料理をご用意しております</p>
+            </div>
+            <div class="course-list">
+                <div class="course-item">
+                    <div class="course-image">
+                        <img src="https://images.unsplash.com/photo-1544025162-d76694265947?w=600&h=400&fit=crop" alt="Lunch Course">
+                    </div>
+                    <div class="course-details">
+                        <h3>Lunch Course</h3>
+                        <p class="course-price">¥5,500〜</p>
+                        <ul class="course-menu">
+                            <li>アミューズ</li>
+                            <li>前菜</li>
+                            <li>スープ</li>
+                            <li>魚料理または肉料理</li>
+                            <li>デザート</li>
+                            <li>コーヒー・小菓子</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="course-item">
+                    <div class="course-image">
+                        <img src="https://images.unsplash.com/photo-1533777857889-4be0c31b4d9?w=600&h=400&fit=crop" alt="Dinner Course">
+                    </div>
+                    <div class="course-details">
+                        <h3>Dinner Course</h3>
+                        <p class="course-price">¥12,000〜</p>
+                        <ul class="course-menu">
+                            <li>アミューズ</li>
+                            <li>前菜2品</li>
+                            <li>スープ</li>
+                            <li>魚料理</li>
+                            <li>肉料理</li>
+                            <li>チーズ</li>
+                            <li>デザート</li>
+                            <li>コーヒー・小菓子</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="course-item special">
+                    <div class="course-image">
+                        <img src="https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=600&h=400&fit=crop" alt="Chef's Special">
+                    </div>
+                    <div class="course-details">
+                        <h3>Chef's Special</h3>
+                        <p class="course-price">¥20,000〜</p>
+                        <p class="course-description">シェフおまかせの特別コース。その日最高の食材を使用した、贅沢な食体験をお楽しみください。</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="chef" class="chef">
+        <div class="container">
+            <h2 class="section-title">Executive Chef</h2>
+            <div class="chef-profile">
+                <div class="chef-image">
+                    <img src="https://images.unsplash.com/photo-1583394293214-28ded15ee548?w=600&h=800&fit=crop" alt="Executive Chef">
+                </div>
+                <div class="chef-info">
+                    <h3>山田 太郎</h3>
+                    <p class="chef-title">Executive Chef / Owner</p>
+                    <div class="chef-bio">
+                        <p>1975年東京生まれ。都内有名ホテルで修行後、25歳で渡仏。</p>
+                        <p>パリの三つ星レストランで5年間研鑽を積み、2008年に帰国。</p>
+                        <p>2010年、Le Jardinをオープン。伝統的なフランス料理に日本の四季を取り入れた独創的な料理で、多くの美食家を魅了している。</p>
+                    </div>
+                    <div class="chef-awards">
+                        <h4>受賞歴</h4>
+                        <ul>
+                            <li>2015年 ミシュラン一つ星獲得</li>
+                            <li>2018年 ミシュラン二つ星獲得</li>
+                            <li>2020年 料理マスターズ受賞</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="gallery">
+        <h2 class="section-title">Gallery</h2>
+        <div class="gallery-grid">
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1550966871-3ed3cdb5ed0c?w=600&h=600&fit=crop" alt="Dish 1">
+            </div>
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1546833999-b9f581a1996d?w=600&h=600&fit=crop" alt="Dish 2">
+            </div>
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1555396273-367ea4eb4db5?w=600&h=600&fit=crop" alt="Interior">
+            </div>
+            <div class="gallery-item">
+                <img src="https://images.unsplash.com/photo-1567620905732-2d1ec7ab7445?w=600&h=600&fit=crop" alt="Dish 3">
+            </div>
+        </div>
+    </section>
+
+    <section class="video-section">
+        <div class="container">
+            <h2 class="section-title">Experience Le Jardin</h2>
+            <div class="video-wrapper">
+                <iframe 
+                    src="https://www.youtube.com/embed/OOcP6vGdUZo" 
+                    title="Restaurant Experience" 
+                    frameborder="0" 
+                    allowfullscreen>
+                </iframe>
+            </div>
+        </div>
+    </section>
+
+    <section id="info" class="info">
+        <div class="container">
+            <h2 class="section-title">Information</h2>
+            <div class="info-content">
+                <div class="info-details">
+                    <h3>営業時間</h3>
+                    <p>Lunch: 12:00 - 14:30 (L.O. 13:30)</p>
+                    <p>Dinner: 18:00 - 22:00 (L.O. 20:30)</p>
+                    <p>定休日: 月曜日、第1・第3火曜日</p>
+                    
+                    <h3>アクセス</h3>
+                    <p>〒106-0032</p>
+                    <p>東京都港区六本木7-14-23</p>
+                    <p>セントラルビル 2F</p>
+                    <p>六本木駅より徒歩3分</p>
+                    
+                    <h3>お問い合わせ</h3>
+                    <p>TEL: 03-5678-9012</p>
+                    <p>Email: info@lejardin.jp</p>
+                </div>
+                <div class="info-map">
+                    <img src="https://images.unsplash.com/photo-1524634126442-357e0eac3c14?w=600&h=400&fit=crop" alt="Restaurant exterior">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="reservation" class="reservation">
+        <div class="container">
+            <h2 class="section-title">Reservation</h2>
+            <div class="reservation-content">
+                <p>ご予約は、お電話またはオンラインにて承っております</p>
+                <div class="reservation-buttons">
+                    <a href="tel:03-5678-9012" class="btn-phone">
+                        お電話で予約<br>
+                        <span>03-5678-9012</span>
+                    </a>
+                    <button class="btn-online">オンライン予約</button>
+                </div>
+                <p class="reservation-note">※ご予約は2ヶ月前から承っております</p>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <h3>Le Jardin</h3>
+            <p>Fine Dining Restaurant</p>
+            <div class="social-links">
+                <a href="#">Facebook</a>
+                <a href="#">Instagram</a>
+                <a href="#">Twitter</a>
+            </div>
+        </div>
+        <p class="copyright">&copy; 2025 Le Jardin. All rights reserved.</p>
+    </footer>
+</body>
+</html>`,
+    css: `* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Georgia', 'Noto Serif JP', serif;
+    color: #333;
+    line-height: 1.8;
+    background: #faf9f7;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Header */
+.header {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    z-index: 1000;
+    padding: 20px 0;
+    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.05);
+}
+
+.header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo {
+    font-size: 32px;
+    font-weight: 300;
+    color: #8b7355;
+}
+
+.navigation ul {
+    display: flex;
+    list-style: none;
+    gap: 40px;
+}
+
+.navigation a {
+    text-decoration: none;
+    color: #333;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    transition: color 0.3s;
+}
+
+.navigation a:hover {
+    color: #8b7355;
+}
+
+.reservation-link {
+    background: #8b7355;
+    color: white !important;
+    padding: 10px 20px;
+    border-radius: 2px;
+}
+
+.reservation-link:hover {
+    background: #6d5a44;
+}
+
+/* Hero */
+.hero {
+    height: 100vh;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.hero-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.4);
+}
+
+.hero-content {
+    text-align: center;
+    color: white;
+}
+
+.hero-title {
+    font-size: 72px;
+    font-weight: 300;
+    margin-bottom: 20px;
+}
+
+.hero-subtitle {
+    font-size: 24px;
+    font-style: italic;
+    margin-bottom: 10px;
+}
+
+.hero-description {
+    font-size: 16px;
+    opacity: 0.9;
+}
+
+/* Sections */
+section {
+    padding: 100px 0;
+}
+
+.section-title {
+    text-align: center;
+    font-size: 42px;
+    font-weight: 300;
+    color: #8b7355;
+    margin-bottom: 60px;
+    position: relative;
+}
+
+.section-title::after {
+    content: '';
+    position: absolute;
+    bottom: -20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60px;
+    height: 2px;
+    background: #8b7355;
+}
+
+/* Concept */
+.concept {
+    background: white;
+}
+
+.concept-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    align-items: center;
+}
+
+.concept-image img {
+    width: 100%;
+    height: 600px;
+    object-fit: cover;
+}
+
+.concept-text h3 {
+    font-size: 28px;
+    color: #8b7355;
+    margin-bottom: 30px;
+}
+
+.concept-text p {
+    margin-bottom: 20px;
+    line-height: 2;
+}
+
+/* Menu */
+.menu-intro {
+    text-align: center;
+    margin-bottom: 60px;
+    font-size: 18px;
+    color: #666;
+}
+
+.course-list {
+    display: grid;
+    gap: 60px;
+}
+
+.course-item {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+    align-items: center;
+    padding: 40px;
+    background: white;
+    box-shadow: 0 5px 30px rgba(0, 0, 0, 0.08);
+}
+
+.course-item.special {
+    background: linear-gradient(135deg, #f5f5f5 0%, #fff 100%);
+    border: 2px solid #8b7355;
+}
+
+.course-image img {
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+}
+
+.course-details h3 {
+    font-size: 28px;
+    color: #8b7355;
+    margin-bottom: 10px;
+}
+
+.course-price {
+    font-size: 24px;
+    color: #666;
+    margin-bottom: 20px;
+}
+
+.course-menu {
+    list-style: none;
+    line-height: 2;
+}
+
+.course-menu li::before {
+    content: "・";
+    margin-right: 10px;
+    color: #8b7355;
+}
+
+.course-description {
+    line-height: 1.8;
+}
+
+/* Chef */
+.chef {
+    background: white;
+}
+
+.chef-profile {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 60px;
+    align-items: start;
+}
+
+.chef-image img {
+    width: 100%;
+    height: 500px;
+    object-fit: cover;
+}
+
+.chef-info h3 {
+    font-size: 32px;
+    color: #8b7355;
+    margin-bottom: 10px;
+}
+
+.chef-title {
+    font-size: 18px;
+    color: #666;
+    margin-bottom: 30px;
+    font-style: italic;
+}
+
+.chef-bio p {
+    margin-bottom: 15px;
+}
+
+.chef-awards {
+    margin-top: 40px;
+    padding-top: 30px;
+    border-top: 1px solid #e0e0e0;
+}
+
+.chef-awards h4 {
+    font-size: 20px;
+    color: #8b7355;
+    margin-bottom: 20px;
+}
+
+.chef-awards ul {
+    list-style: none;
+}
+
+.chef-awards li {
+    margin-bottom: 10px;
+    padding-left: 20px;
+    position: relative;
+}
+
+.chef-awards li::before {
+    content: "★";
+    position: absolute;
+    left: 0;
+    color: #8b7355;
+}
+
+/* Gallery */
+.gallery {
+    padding: 0;
+}
+
+.gallery .section-title {
+    padding: 100px 0 60px;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+}
+
+.gallery-item {
+    overflow: hidden;
+    aspect-ratio: 1;
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s;
+}
+
+.gallery-item:hover img {
+    transform: scale(1.1);
+}
+
+/* Video Section */
+.video-section {
+    background: white;
+}
+
+.video-wrapper {
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+
+.video-wrapper iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+/* Info */
+.info-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+}
+
+.info-details h3 {
+    font-size: 24px;
+    color: #8b7355;
+    margin: 30px 0 15px;
+}
+
+.info-details h3:first-child {
+    margin-top: 0;
+}
+
+.info-details p {
+    margin-bottom: 10px;
+}
+
+.info-map img {
+    width: 100%;
+    height: 400px;
+    object-fit: cover;
+}
+
+/* Reservation */
+.reservation {
+    background: linear-gradient(135deg, #8b7355 0%, #6d5a44 100%);
+    color: white;
+}
+
+.reservation .section-title {
+    color: white;
+}
+
+.reservation .section-title::after {
+    background: white;
+}
+
+.reservation-content {
+    text-align: center;
+}
+
+.reservation-content > p {
+    font-size: 18px;
+    margin-bottom: 40px;
+}
+
+.reservation-buttons {
+    display: flex;
+    gap: 30px;
+    justify-content: center;
+    margin-bottom: 30px;
+}
+
+.btn-phone, .btn-online {
+    padding: 20px 40px;
+    font-size: 16px;
+    border: 2px solid white;
+    background: transparent;
+    color: white;
+    text-decoration: none;
+    transition: all 0.3s;
+    cursor: pointer;
+}
+
+.btn-phone:hover, .btn-online:hover {
+    background: white;
+    color: #8b7355;
+}
+
+.btn-phone span {
+    display: block;
+    font-size: 20px;
+    margin-top: 5px;
+}
+
+.reservation-note {
+    font-size: 14px;
+    opacity: 0.8;
+}
+
+/* Footer */
+.footer {
+    background: #2c2c2c;
+    color: white;
+    padding: 50px 0 20px;
+    text-align: center;
+}
+
+.footer-content h3 {
+    font-size: 28px;
+    margin-bottom: 10px;
+}
+
+.footer-content p {
+    margin-bottom: 30px;
+    color: #999;
+}
+
+.social-links {
+    display: flex;
+    gap: 30px;
+    justify-content: center;
+    margin-bottom: 30px;
+}
+
+.social-links a {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+.social-links a:hover {
+    color: #8b7355;
+}
+
+.copyright {
+    padding-top: 30px;
+    border-top: 1px solid #444;
+    color: #666;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .navigation ul {
+        flex-direction: column;
+        gap: 15px;
+    }
+    
+    .hero-title {
+        font-size: 48px;
+    }
+    
+    .concept-content,
+    .course-item,
+    .chef-profile,
+    .info-content {
+        grid-template-columns: 1fr;
+    }
+    
+    .gallery-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .reservation-buttons {
+        flex-direction: column;
+    }
+}`,
+    js: `// スムーズスクロール
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function (e) {
+        e.preventDefault();
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+            const headerHeight = document.querySelector('.header').offsetHeight;
+            const targetPosition = target.offsetTop - headerHeight;
+            window.scrollTo({
+                top: targetPosition,
+                behavior: 'smooth'
+            });
+        }
+    });
+});
+
+// 予約ボタン
+document.querySelector('.btn-online').addEventListener('click', function() {
+    alert('オンライン予約システムへ移動します（実装予定）');
+});
+
+// ヘッダー透明度変更
+window.addEventListener('scroll', function() {
+    const header = document.querySelector('.header');
+    if (window.scrollY > 100) {
+        header.style.background = 'rgba(255, 255, 255, 1)';
+    } else {
+        header.style.background = 'rgba(255, 255, 255, 0.95)';
+    }
+});
+
+// ギャラリー画像のライトボックス風効果
+document.querySelectorAll('.gallery-item').forEach(item => {
+    item.addEventListener('click', function() {
+        const img = this.querySelector('img');
+        alert(\`画像を拡大表示: \${img.alt}\`);
+    });
+});`
+  }
+}

--- a/src/lib/templates/data/retail-fashion.ts
+++ b/src/lib/templates/data/retail-fashion.ts
@@ -49,6 +49,9 @@ export const retailFashionTemplate: WebTemplate = {
     </header>
 
     <section class="hero-section">
+        <div class="hero-image">
+            <img src="https://images.unsplash.com/photo-1490481651871-ab68de25d43d?w=1920&h=800&fit=crop" alt="Fashion Collection">
+        </div>
         <div class="hero-content">
             <h2>2025 Spring Collection</h2>
             <p>新作コレクション入荷</p>
@@ -63,7 +66,7 @@ export const retailFashionTemplate: WebTemplate = {
                 <div class="product-card">
                     <div class="product-image">
                         <span class="badge new">NEW</span>
-                        <div class="product-placeholder">商品画像</div>
+                        <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=400&h=500&fit=crop" alt="デザイナーTシャツ">
                     </div>
                     <div class="product-info">
                         <h3>デザイナーTシャツ</h3>
@@ -74,7 +77,7 @@ export const retailFashionTemplate: WebTemplate = {
                 <div class="product-card">
                     <div class="product-image">
                         <span class="badge new">NEW</span>
-                        <div class="product-placeholder">商品画像</div>
+                        <img src="https://images.unsplash.com/photo-1542272604-787c3835535d?w=400&h=500&fit=crop" alt="スリムフィットデニム">
                     </div>
                     <div class="product-info">
                         <h3>スリムフィットデニム</h3>
@@ -85,7 +88,7 @@ export const retailFashionTemplate: WebTemplate = {
                 <div class="product-card">
                     <div class="product-image">
                         <span class="badge sale">SALE</span>
-                        <div class="product-placeholder">商品画像</div>
+                        <img src="https://images.unsplash.com/photo-1591047139829-d91aecb6caea?w=400&h=500&fit=crop" alt="カジュアルジャケット">
                     </div>
                     <div class="product-info">
                         <h3>カジュアルジャケット</h3>
@@ -98,7 +101,7 @@ export const retailFashionTemplate: WebTemplate = {
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <div class="product-placeholder">商品画像</div>
+                        <img src="https://images.unsplash.com/photo-1572804013427-4d7ca7268217?w=400&h=500&fit=crop" alt="ワンピース">
                     </div>
                     <div class="product-info">
                         <h3>ワンピース</h3>
@@ -275,12 +278,34 @@ button {
 
 .hero-section {
     height: 500px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     color: white;
+    overflow: hidden;
+}
+
+.hero-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+}
+
+.hero-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.3);
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
 }
 
 .hero-content h2 {
@@ -341,13 +366,15 @@ button {
     margin-bottom: 15px;
 }
 
-.product-placeholder {
+.product-image img {
+    width: 100%;
     height: 350px;
-    background: #f0f0f0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #999;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.product-card:hover .product-image img {
+    transform: scale(1.05);
 }
 
 .badge {
@@ -490,18 +517,43 @@ button {
 }
 
 @media (max-width: 768px) {
-    .main-nav {
-        flex-wrap: wrap;
+    .header-container {
+        flex-direction: column;
         gap: 15px;
     }
     
+    .main-nav {
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 10px 0;
+    }
+    
+    .main-nav a {
+        font-size: 12px;
+        padding: 0 10px;
+    }
+    
     .hero-content h2 {
-        font-size: 32px;
+        font-size: 28px;
+    }
+    
+    .hero-content p {
+        font-size: 16px;
     }
     
     .products-grid {
         grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 15px;
+    }
+    
+    .features-grid {
+        grid-template-columns: repeat(2, 1fr);
         gap: 20px;
+    }
+    
+    .footer-content {
+        grid-template-columns: 1fr;
+        text-align: center;
     }
 }`,
     js: `// カート機能のシミュレーション

--- a/src/lib/templates/data/retail-general.ts
+++ b/src/lib/templates/data/retail-general.ts
@@ -1,0 +1,779 @@
+import { WebTemplate, TEMPLATE_CATEGORIES } from '../types'
+
+export const retailGeneralTemplate: WebTemplate = {
+  id: 'retail-general',
+  title: '小売店 - 雑貨',
+  category: TEMPLATE_CATEGORIES.RETAIL,
+  description: 'おしゃれな雑貨店向けのWebサイトテンプレート',
+  thumbnail: '/template-images/retail-general.jpg',
+  features: [
+    'Instagram連携',
+    '商品カタログ',
+    'ブログ機能',
+    'お気に入り機能'
+  ],
+  tags: ['小売店', '雑貨', 'ライフスタイル', 'インスタ映え'],
+  code: {
+    html: `<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ZAKKA STORE - 暮らしを彩る雑貨たち</title>
+</head>
+<body>
+    <header class="header">
+        <div class="header-top">
+            <div class="container">
+                <p class="header-message">3,000円以上で送料無料 ｜ ギフトラッピング承ります</p>
+            </div>
+        </div>
+        <div class="header-main">
+            <div class="container">
+                <div class="header-content">
+                    <h1 class="logo">ZAKKA STORE</h1>
+                    <nav class="nav">
+                        <ul>
+                            <li><a href="#new">New Items</a></li>
+                            <li><a href="#category">Category</a></li>
+                            <li><a href="#about">About</a></li>
+                            <li><a href="#blog">Blog</a></li>
+                            <li><a href="#contact">Contact</a></li>
+                        </ul>
+                    </nav>
+                    <div class="header-actions">
+                        <button class="search-btn">🔍</button>
+                        <button class="wishlist-btn">♡</button>
+                        <button class="cart-btn">🛒</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <section class="hero">
+        <div class="hero-slider">
+            <div class="slide active">
+                <img src="https://images.unsplash.com/photo-1555529669-e69e7aa0ba9a?w=1920&h=600&fit=crop" alt="雑貨コレクション">
+                <div class="slide-content">
+                    <h2>Spring Collection 2025</h2>
+                    <p>新生活を彩る春の新作が入荷しました</p>
+                    <a href="#" class="btn-primary">コレクションを見る</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="new" class="new-items">
+        <div class="container">
+            <h2 class="section-title">New Items</h2>
+            <div class="product-grid">
+                <div class="product-card">
+                    <div class="product-image">
+                        <img src="https://images.unsplash.com/photo-1540932239986-30128078f3c5?w=400&h=400&fit=crop" alt="北欧風花瓶">
+                        <span class="badge">NEW</span>
+                        <button class="wishlist-add">♡</button>
+                    </div>
+                    <div class="product-info">
+                        <h3>北欧風フラワーベース</h3>
+                        <p class="price">¥3,200</p>
+                    </div>
+                </div>
+                <div class="product-card">
+                    <div class="product-image">
+                        <img src="https://images.unsplash.com/photo-1523251343397-9225e4cb6319?w=400&h=400&fit=crop" alt="アロマキャンドル">
+                        <span class="badge">NEW</span>
+                        <button class="wishlist-add">♡</button>
+                    </div>
+                    <div class="product-info">
+                        <h3>オーガニックアロマキャンドル</h3>
+                        <p class="price">¥2,800</p>
+                    </div>
+                </div>
+                <div class="product-card">
+                    <div class="product-image">
+                        <img src="https://images.unsplash.com/photo-1565193566173-7a0ee3dbe261?w=400&h=400&fit=crop" alt="木製トレイ">
+                        <span class="badge">NEW</span>
+                        <button class="wishlist-add">♡</button>
+                    </div>
+                    <div class="product-info">
+                        <h3>天然木トレイ</h3>
+                        <p class="price">¥4,500</p>
+                    </div>
+                </div>
+                <div class="product-card">
+                    <div class="product-image">
+                        <img src="https://images.unsplash.com/photo-1522444690501-325c900eedf0?w=400&h=400&fit=crop" alt="クッションカバー">
+                        <button class="wishlist-add">♡</button>
+                    </div>
+                    <div class="product-info">
+                        <h3>リネンクッションカバー</h3>
+                        <p class="price">¥2,200</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="category" class="categories">
+        <div class="container">
+            <h2 class="section-title">Category</h2>
+            <div class="category-grid">
+                <a href="#" class="category-item">
+                    <img src="https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=600&h=400&fit=crop" alt="キッチン">
+                    <div class="category-overlay">
+                        <h3>Kitchen</h3>
+                        <p>キッチン雑貨</p>
+                    </div>
+                </a>
+                <a href="#" class="category-item">
+                    <img src="https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=600&h=400&fit=crop" alt="リビング">
+                    <div class="category-overlay">
+                        <h3>Living</h3>
+                        <p>リビング雑貨</p>
+                    </div>
+                </a>
+                <a href="#" class="category-item">
+                    <img src="https://images.unsplash.com/photo-1523755231516-e43fd2e8dca5?w=600&h=400&fit=crop" alt="バス">
+                    <div class="category-overlay">
+                        <h3>Bath</h3>
+                        <p>バス・トイレタリー</p>
+                    </div>
+                </a>
+                <a href="#" class="category-item">
+                    <img src="https://images.unsplash.com/photo-1513506003901-1e6a229e2d15?w=600&h=400&fit=crop" alt="ステーショナリー">
+                    <div class="category-overlay">
+                        <h3>Stationery</h3>
+                        <p>文房具</p>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section id="instagram" class="instagram-feed">
+        <div class="container">
+            <h2 class="section-title">Instagram</h2>
+            <p class="instagram-handle">@zakka_store</p>
+            <div class="instagram-grid">
+                <div class="instagram-item">
+                    <img src="https://images.unsplash.com/photo-1556228453-efd6c1ff04f6?w=300&h=300&fit=crop" alt="Instagram1">
+                </div>
+                <div class="instagram-item">
+                    <img src="https://images.unsplash.com/photo-1556228841-a3c527ebefe5?w=300&h=300&fit=crop" alt="Instagram2">
+                </div>
+                <div class="instagram-item">
+                    <img src="https://images.unsplash.com/photo-1556228720-195a672e8a03?w=300&h=300&fit=crop" alt="Instagram3">
+                </div>
+                <div class="instagram-item">
+                    <img src="https://images.unsplash.com/photo-1556228578-0d85b1a4d571?w=300&h=300&fit=crop" alt="Instagram4">
+                </div>
+                <div class="instagram-item">
+                    <img src="https://images.unsplash.com/photo-1556228852-80b6bb058128?w=300&h=300&fit=crop" alt="Instagram5">
+                </div>
+                <div class="instagram-item">
+                    <img src="https://images.unsplash.com/photo-1556909212-d5b604d0c90d?w=300&h=300&fit=crop" alt="Instagram6">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="blog" class="blog">
+        <div class="container">
+            <h2 class="section-title">Blog</h2>
+            <div class="blog-grid">
+                <article class="blog-card">
+                    <img src="https://images.unsplash.com/photo-1511401139252-f158d3209c17?w=600&h=400&fit=crop" alt="ブログ1">
+                    <div class="blog-content">
+                        <time>2025.08.01</time>
+                        <h3>北欧インテリアの作り方</h3>
+                        <p>シンプルで温かみのある北欧スタイルのお部屋作りのコツをご紹介します。</p>
+                        <a href="#" class="read-more">続きを読む →</a>
+                    </div>
+                </article>
+                <article class="blog-card">
+                    <img src="https://images.unsplash.com/photo-1520981825232-ece5fae45120?w=600&h=400&fit=crop" alt="ブログ2">
+                    <div class="blog-content">
+                        <time>2025.07.28</time>
+                        <h3>ギフトラッピングのアイデア</h3>
+                        <p>大切な人への贈り物を特別にする、おしゃれなラッピング方法をご紹介。</p>
+                        <a href="#" class="read-more">続きを読む →</a>
+                    </div>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section id="about" class="about">
+        <div class="container">
+            <h2 class="section-title">About Us</h2>
+            <div class="about-content">
+                <div class="about-text">
+                    <h3>暮らしを彩る雑貨たち</h3>
+                    <p>ZAKKA STOREは、毎日の暮らしをもっと楽しく、もっと心地よくする雑貨を世界中からセレクトしています。</p>
+                    <p>北欧、フランス、日本...様々な国の素敵なアイテムを取り揃え、お客様の理想のライフスタイルづくりをお手伝いします。</p>
+                    <p>実店舗では、季節ごとのディスプレイやワークショップも開催しています。</p>
+                </div>
+                <div class="about-video">
+                    <iframe 
+                        width="560" 
+                        height="315" 
+                        src="https://www.youtube.com/embed/MLpWrANjFbI" 
+                        title="Store Introduction" 
+                        frameborder="0" 
+                        allowfullscreen>
+                    </iframe>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>ZAKKA STORE</h3>
+                    <p>〒150-0001 東京都渋谷区神宮前3-15-8</p>
+                    <p>TEL: 03-1234-5678</p>
+                    <p>営業時間: 11:00-20:00</p>
+                </div>
+                <div class="footer-section">
+                    <h3>Follow Us</h3>
+                    <div class="social-links">
+                        <a href="#">Instagram</a>
+                        <a href="#">Facebook</a>
+                        <a href="#">Pinterest</a>
+                    </div>
+                </div>
+                <div class="footer-section">
+                    <h3>Newsletter</h3>
+                    <p>新商品やセール情報をお届けします</p>
+                    <form class="newsletter-form">
+                        <input type="email" placeholder="メールアドレス">
+                        <button type="submit">登録</button>
+                    </form>
+                </div>
+            </div>
+            <p class="copyright">&copy; 2025 ZAKKA STORE. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>`,
+    css: `* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Helvetica Neue', 'Yu Gothic', sans-serif;
+    color: #333;
+    line-height: 1.6;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Header */
+.header-top {
+    background: #f8f8f8;
+    padding: 10px 0;
+    text-align: center;
+    font-size: 14px;
+    color: #666;
+}
+
+.header-main {
+    background: white;
+    padding: 20px 0;
+    border-bottom: 1px solid #eee;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo {
+    font-size: 28px;
+    font-weight: 300;
+    letter-spacing: 3px;
+}
+
+.nav ul {
+    display: flex;
+    list-style: none;
+    gap: 30px;
+}
+
+.nav a {
+    text-decoration: none;
+    color: #333;
+    font-size: 14px;
+    transition: color 0.3s;
+}
+
+.nav a:hover {
+    color: #d4a574;
+}
+
+.header-actions {
+    display: flex;
+    gap: 20px;
+}
+
+.header-actions button {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    transition: transform 0.3s;
+}
+
+.header-actions button:hover {
+    transform: scale(1.1);
+}
+
+/* Hero */
+.hero {
+    position: relative;
+    height: 600px;
+    overflow: hidden;
+}
+
+.slide {
+    position: relative;
+    height: 100%;
+}
+
+.slide img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.slide-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: white;
+}
+
+.slide-content h2 {
+    font-size: 48px;
+    font-weight: 300;
+    margin-bottom: 20px;
+}
+
+.slide-content p {
+    font-size: 18px;
+    margin-bottom: 30px;
+}
+
+.btn-primary {
+    display: inline-block;
+    padding: 12px 30px;
+    background: white;
+    color: #333;
+    text-decoration: none;
+    transition: background 0.3s, color 0.3s;
+}
+
+.btn-primary:hover {
+    background: #333;
+    color: white;
+}
+
+/* Sections */
+section {
+    padding: 80px 0;
+}
+
+.section-title {
+    text-align: center;
+    font-size: 36px;
+    font-weight: 300;
+    margin-bottom: 50px;
+    letter-spacing: 2px;
+}
+
+/* Products */
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 30px;
+}
+
+.product-card {
+    position: relative;
+}
+
+.product-image {
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 15px;
+}
+
+.product-image img {
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.product-card:hover .product-image img {
+    transform: scale(1.05);
+}
+
+.badge {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: #d4a574;
+    color: white;
+    padding: 5px 10px;
+    font-size: 12px;
+}
+
+.wishlist-add {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: white;
+    border: none;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    font-size: 18px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.wishlist-add:hover {
+    background: #ffe0e0;
+}
+
+.product-info h3 {
+    font-size: 16px;
+    margin-bottom: 8px;
+}
+
+.price {
+    font-size: 18px;
+    color: #d4a574;
+}
+
+/* Categories */
+.categories {
+    background: #f8f8f8;
+}
+
+.category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+}
+
+.category-item {
+    position: relative;
+    overflow: hidden;
+    height: 250px;
+    text-decoration: none;
+}
+
+.category-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.category-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    transition: background 0.3s;
+}
+
+.category-item:hover .category-overlay {
+    background: rgba(0, 0, 0, 0.6);
+}
+
+.category-item:hover img {
+    transform: scale(1.1);
+}
+
+.category-overlay h3 {
+    font-size: 28px;
+    font-weight: 300;
+    margin-bottom: 10px;
+}
+
+/* Instagram */
+.instagram-handle {
+    text-align: center;
+    font-size: 18px;
+    color: #666;
+    margin-bottom: 30px;
+}
+
+.instagram-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px;
+}
+
+.instagram-item {
+    overflow: hidden;
+    aspect-ratio: 1;
+}
+
+.instagram-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.instagram-item:hover img {
+    transform: scale(1.1);
+}
+
+/* Blog */
+.blog-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 30px;
+}
+
+.blog-card {
+    background: white;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+.blog-card img {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+}
+
+.blog-content {
+    padding: 30px;
+}
+
+.blog-content time {
+    color: #999;
+    font-size: 14px;
+}
+
+.blog-content h3 {
+    margin: 10px 0;
+    font-size: 20px;
+}
+
+.blog-content p {
+    color: #666;
+    margin-bottom: 15px;
+}
+
+.read-more {
+    color: #d4a574;
+    text-decoration: none;
+    font-size: 14px;
+}
+
+/* About */
+.about {
+    background: #f8f8f8;
+}
+
+.about-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
+    align-items: center;
+}
+
+.about-text h3 {
+    font-size: 24px;
+    margin-bottom: 20px;
+}
+
+.about-text p {
+    margin-bottom: 15px;
+    line-height: 1.8;
+}
+
+.about-video iframe {
+    width: 100%;
+    height: 315px;
+}
+
+/* Footer */
+.footer {
+    background: #333;
+    color: white;
+    padding: 50px 0 20px;
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 40px;
+    margin-bottom: 30px;
+}
+
+.footer-section h3 {
+    margin-bottom: 20px;
+}
+
+.social-links {
+    display: flex;
+    gap: 20px;
+}
+
+.social-links a {
+    color: white;
+    text-decoration: none;
+}
+
+.newsletter-form {
+    display: flex;
+    margin-top: 15px;
+}
+
+.newsletter-form input {
+    flex: 1;
+    padding: 10px;
+    border: none;
+}
+
+.newsletter-form button {
+    padding: 10px 20px;
+    background: #d4a574;
+    border: none;
+    color: white;
+    cursor: pointer;
+}
+
+.copyright {
+    text-align: center;
+    padding-top: 30px;
+    border-top: 1px solid #555;
+    color: #999;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .header-content {
+        flex-direction: column;
+        gap: 20px;
+    }
+    
+    .nav ul {
+        flex-direction: column;
+        text-align: center;
+        gap: 15px;
+    }
+    
+    .slide-content h2 {
+        font-size: 32px;
+    }
+    
+    .about-content {
+        grid-template-columns: 1fr;
+    }
+    
+    .category-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .blog-grid {
+        grid-template-columns: 1fr;
+    }
+}`,
+    js: `// お気に入り機能
+let wishlist = [];
+
+document.querySelectorAll('.wishlist-add').forEach(button => {
+    button.addEventListener('click', function() {
+        if (this.textContent === '♡') {
+            this.textContent = '♥';
+            this.style.color = 'red';
+            wishlist.push(this.closest('.product-card'));
+        } else {
+            this.textContent = '♡';
+            this.style.color = 'black';
+        }
+        updateWishlistCount();
+    });
+});
+
+function updateWishlistCount() {
+    const count = document.querySelectorAll('.wishlist-add').length;
+    console.log(\`Wishlist items: \${wishlist.length}\`);
+}
+
+// 検索機能
+document.querySelector('.search-btn').addEventListener('click', function() {
+    const searchTerm = prompt('商品を検索:');
+    if (searchTerm) {
+        alert(\`"\${searchTerm}" の検索結果を表示\`);
+    }
+});
+
+// カート機能
+document.querySelector('.cart-btn').addEventListener('click', function() {
+    alert('カートページへ移動');
+});
+
+// ニュースレター
+document.querySelector('.newsletter-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const email = this.querySelector('input').value;
+    if (email) {
+        alert(\`\${email} を登録しました\`);
+        this.querySelector('input').value = '';
+    }
+});
+
+// スムーズスクロール
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function (e) {
+        e.preventDefault();
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+            const headerHeight = document.querySelector('.header-main').offsetHeight;
+            const targetPosition = target.offsetTop - headerHeight;
+            window.scrollTo({
+                top: targetPosition,
+                behavior: 'smooth'
+            });
+        }
+    });
+});`
+  }
+}

--- a/src/lib/templates/data/service-beauty.ts
+++ b/src/lib/templates/data/service-beauty.ts
@@ -1,0 +1,955 @@
+import { WebTemplate, TEMPLATE_CATEGORIES } from '../types'
+
+export const serviceBeautyTemplate: WebTemplate = {
+  id: 'service-beauty',
+  title: 'サービス業 - 美容室',
+  category: TEMPLATE_CATEGORIES.SERVICE,
+  description: 'スタイリッシュな美容室・ヘアサロン向けWebサイトテンプレート',
+  thumbnail: '/template-images/service-beauty.jpg',
+  features: [
+    'スタイルギャラリー',
+    'スタッフ紹介',
+    'メニュー料金表',
+    'オンライン予約'
+  ],
+  tags: ['サービス業', '美容室', 'ヘアサロン', 'ビューティー'],
+  code: {
+    html: `<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HAIR STUDIO LUMINOUS - 輝く髪と笑顔のために</title>
+</head>
+<body>
+    <header class="header">
+        <div class="header-inner">
+            <div class="logo">
+                <span class="logo-main">LUMINOUS</span>
+                <span class="logo-sub">HAIR STUDIO</span>
+            </div>
+            <nav class="nav">
+                <ul>
+                    <li><a href="#concept">Concept</a></li>
+                    <li><a href="#menu">Menu</a></li>
+                    <li><a href="#style">Style</a></li>
+                    <li><a href="#staff">Staff</a></li>
+                    <li><a href="#access">Access</a></li>
+                </ul>
+            </nav>
+            <a href="#booking" class="booking-btn">ご予約</a>
+        </div>
+    </header>
+
+    <section class="hero">
+        <div class="hero-slider">
+            <div class="slide active">
+                <img src="https://images.unsplash.com/photo-1562322140-8baeececf3df?w=1920&h=1080&fit=crop" alt="サロン内観">
+            </div>
+        </div>
+        <div class="hero-content">
+            <h1>あなたの魅力を<br>最大限に引き出す</h1>
+            <p>一人ひとりの個性に合わせたスタイル提案</p>
+            <a href="#booking" class="cta-button">今すぐ予約する</a>
+        </div>
+    </section>
+
+    <section id="concept" class="concept">
+        <div class="container">
+            <h2 class="section-title">Concept</h2>
+            <div class="concept-content">
+                <div class="concept-text">
+                    <h3>髪から始まる、新しい自分</h3>
+                    <p>HAIR STUDIO LUMINOUSは、お客様一人ひとりの魅力を最大限に引き出すことを目指しています。</p>
+                    <p>最新のトレンドと確かな技術で、あなただけのスタイルをご提案。</p>
+                    <p>リラックスできる空間で、特別な時間をお過ごしください。</p>
+                </div>
+                <div class="concept-image">
+                    <img src="https://images.unsplash.com/photo-1633681926035-ec1ac984418a?w=600&h=400&fit=crop" alt="サロンコンセプト">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="menu" class="menu">
+        <div class="container">
+            <h2 class="section-title">Menu & Price</h2>
+            <div class="menu-tabs">
+                <button class="tab-btn active" data-tab="cut">カット</button>
+                <button class="tab-btn" data-tab="color">カラー</button>
+                <button class="tab-btn" data-tab="perm">パーマ</button>
+                <button class="tab-btn" data-tab="treatment">トリートメント</button>
+            </div>
+            <div class="menu-content">
+                <div class="tab-content active" id="cut">
+                    <div class="menu-item">
+                        <div class="menu-header">
+                            <h3>カット</h3>
+                            <span class="price">¥5,500</span>
+                        </div>
+                        <p>シャンプー・ブロー込み</p>
+                    </div>
+                    <div class="menu-item">
+                        <div class="menu-header">
+                            <h3>学生カット</h3>
+                            <span class="price">¥4,400</span>
+                        </div>
+                        <p>中高生限定（要学生証）</p>
+                    </div>
+                    <div class="menu-item">
+                        <div class="menu-header">
+                            <h3>前髪カット</h3>
+                            <span class="price">¥1,100</span>
+                        </div>
+                        <p>前髪のみのカット</p>
+                    </div>
+                </div>
+                <div class="tab-content" id="color">
+                    <div class="menu-item">
+                        <div class="menu-header">
+                            <h3>リタッチカラー</h3>
+                            <span class="price">¥6,600</span>
+                        </div>
+                        <p>根元のみ（〜3cm）</p>
+                    </div>
+                    <div class="menu-item">
+                        <div class="menu-header">
+                            <h3>フルカラー</h3>
+                            <span class="price">¥8,800</span>
+                        </div>
+                        <p>全体カラー</p>
+                    </div>
+                    <div class="menu-item">
+                        <div class="menu-header">
+                            <h3>ハイライト・ローライト</h3>
+                            <span class="price">¥11,000〜</span>
+                        </div>
+                        <p>立体感のあるカラーデザイン</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="style" class="style-gallery">
+        <div class="container">
+            <h2 class="section-title">Style Gallery</h2>
+            <div class="style-filters">
+                <button class="filter-btn active" data-filter="all">All</button>
+                <button class="filter-btn" data-filter="short">Short</button>
+                <button class="filter-btn" data-filter="medium">Medium</button>
+                <button class="filter-btn" data-filter="long">Long</button>
+                <button class="filter-btn" data-filter="color">Color</button>
+            </div>
+            <div class="style-grid">
+                <div class="style-item" data-category="short">
+                    <img src="https://images.unsplash.com/photo-1596728325488-58c87691e9af?w=400&h=500&fit=crop" alt="ショートスタイル">
+                    <div class="style-overlay">
+                        <h3>ナチュラルショート</h3>
+                        <p>担当: Yuki</p>
+                    </div>
+                </div>
+                <div class="style-item" data-category="medium">
+                    <img src="https://images.unsplash.com/photo-1605497788044-5a32c7078486?w=400&h=500&fit=crop" alt="ミディアムスタイル">
+                    <div class="style-overlay">
+                        <h3>エアリーボブ</h3>
+                        <p>担当: Mika</p>
+                    </div>
+                </div>
+                <div class="style-item" data-category="long">
+                    <img src="https://images.unsplash.com/photo-1634449571010-02389ed0f9b0?w=400&h=500&fit=crop" alt="ロングスタイル">
+                    <div class="style-overlay">
+                        <h3>ナチュラルウェーブ</h3>
+                        <p>担当: Ken</p>
+                    </div>
+                </div>
+                <div class="style-item" data-category="color">
+                    <img src="https://images.unsplash.com/photo-1617695743585-0e5578e72a62?w=400&h=500&fit=crop" alt="カラースタイル">
+                    <div class="style-overlay">
+                        <h3>グラデーションカラー</h3>
+                        <p>担当: Saki</p>
+                    </div>
+                </div>
+                <div class="style-item" data-category="short">
+                    <img src="https://images.unsplash.com/photo-1615460489547-a534e20c9db1?w=400&h=500&fit=crop" alt="ショートスタイル2">
+                    <div class="style-overlay">
+                        <h3>クールショート</h3>
+                        <p>担当: Tomo</p>
+                    </div>
+                </div>
+                <div class="style-item" data-category="medium">
+                    <img src="https://images.unsplash.com/photo-1492106087820-71f1a00d2b11?w=400&h=500&fit=crop" alt="ミディアムスタイル2">
+                    <div class="style-overlay">
+                        <h3>フェミニンミディ</h3>
+                        <p>担当: Aya</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="staff" class="staff">
+        <div class="container">
+            <h2 class="section-title">Our Staff</h2>
+            <div class="staff-grid">
+                <div class="staff-card">
+                    <img src="https://images.unsplash.com/photo-1580618672591-eb180b1a973f?w=400&h=400&fit=crop" alt="スタイリスト1">
+                    <h3>佐藤 ゆき</h3>
+                    <p class="staff-role">Top Stylist</p>
+                    <p class="staff-message">ナチュラルで扱いやすいスタイルが得意です。</p>
+                    <div class="staff-sns">
+                        <a href="#">Instagram</a>
+                    </div>
+                </div>
+                <div class="staff-card">
+                    <img src="https://images.unsplash.com/photo-1595959183082-7b570b7e08e2?w=400&h=400&fit=crop" alt="スタイリスト2">
+                    <h3>田中 みか</h3>
+                    <p class="staff-role">Stylist</p>
+                    <p class="staff-message">トレンドを取り入れたスタイル提案が得意です。</p>
+                    <div class="staff-sns">
+                        <a href="#">Instagram</a>
+                    </div>
+                </div>
+                <div class="staff-card">
+                    <img src="https://images.unsplash.com/photo-1559599101-f09722fb4948?w=400&h=400&fit=crop" alt="スタイリスト3">
+                    <h3>山田 けん</h3>
+                    <p class="staff-role">Director</p>
+                    <p class="staff-message">お客様の魅力を最大限に引き出します。</p>
+                    <div class="staff-sns">
+                        <a href="#">Instagram</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="instagram">
+        <div class="container">
+            <h2 class="section-title">Instagram</h2>
+            <p class="instagram-id">@luminous_hair</p>
+            <div class="instagram-feed">
+                <img src="https://images.unsplash.com/photo-1620331311520-246422fd82f9?w=300&h=300&fit=crop" alt="Instagram1">
+                <img src="https://images.unsplash.com/photo-1620331317131-c7c2c7a37a01?w=300&h=300&fit=crop" alt="Instagram2">
+                <img src="https://images.unsplash.com/photo-1622287162716-f311baa1a2b8?w=300&h=300&fit=crop" alt="Instagram3">
+                <img src="https://images.unsplash.com/photo-1625948515291-69613efd103f?w=300&h=300&fit=crop" alt="Instagram4">
+            </div>
+        </div>
+    </section>
+
+    <section id="access" class="access">
+        <div class="container">
+            <h2 class="section-title">Access</h2>
+            <div class="access-content">
+                <div class="access-info">
+                    <table>
+                        <tr>
+                            <th>住所</th>
+                            <td>〒150-0041 東京都渋谷区神南1-15-3</td>
+                        </tr>
+                        <tr>
+                            <th>電話</th>
+                            <td>03-6789-0123</td>
+                        </tr>
+                        <tr>
+                            <th>営業時間</th>
+                            <td>
+                                平日: 10:00-20:00<br>
+                                土日祝: 9:00-19:00
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>定休日</th>
+                            <td>毎週火曜日、第1・第3月曜日</td>
+                        </tr>
+                        <tr>
+                            <th>アクセス</th>
+                            <td>JR渋谷駅ハチ公口より徒歩5分</td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="access-video">
+                    <iframe 
+                        src="https://www.youtube.com/embed/HJm9TxGJz-Y" 
+                        title="Salon Tour" 
+                        frameborder="0" 
+                        allowfullscreen>
+                    </iframe>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="booking" class="booking">
+        <div class="container">
+            <h2 class="section-title">Online Booking</h2>
+            <div class="booking-content">
+                <p>24時間いつでもオンラインでご予約いただけます</p>
+                <button class="booking-button">予約画面へ進む</button>
+                <p class="booking-note">
+                    ※初めてご利用の方は、お電話でのご予約をおすすめしています<br>
+                    TEL: 03-6789-0123
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-logo">
+                    <span>LUMINOUS</span>
+                    <span>HAIR STUDIO</span>
+                </div>
+                <div class="footer-links">
+                    <a href="#">プライバシーポリシー</a>
+                    <a href="#">採用情報</a>
+                </div>
+                <div class="footer-social">
+                    <a href="#">Instagram</a>
+                    <a href="#">Facebook</a>
+                    <a href="#">LINE</a>
+                </div>
+            </div>
+            <p class="copyright">&copy; 2025 HAIR STUDIO LUMINOUS. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>`,
+    css: `* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Helvetica Neue', 'Noto Sans JP', sans-serif;
+    color: #333;
+    line-height: 1.6;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Header */
+.header {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(10px);
+    z-index: 1000;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 15px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo {
+    display: flex;
+    flex-direction: column;
+}
+
+.logo-main {
+    font-size: 24px;
+    font-weight: bold;
+    letter-spacing: 3px;
+    color: #d4a574;
+}
+
+.logo-sub {
+    font-size: 10px;
+    letter-spacing: 2px;
+    color: #666;
+}
+
+.nav ul {
+    display: flex;
+    list-style: none;
+    gap: 35px;
+}
+
+.nav a {
+    text-decoration: none;
+    color: #333;
+    font-size: 14px;
+    transition: color 0.3s;
+}
+
+.nav a:hover {
+    color: #d4a574;
+}
+
+.booking-btn {
+    background: #d4a574;
+    color: white;
+    padding: 10px 25px;
+    text-decoration: none;
+    border-radius: 25px;
+    transition: transform 0.3s;
+}
+
+.booking-btn:hover {
+    transform: scale(1.05);
+}
+
+/* Hero */
+.hero {
+    height: 100vh;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero-slider {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.slide img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.5);
+}
+
+.hero-content {
+    text-align: center;
+    color: white;
+}
+
+.hero-content h1 {
+    font-size: 48px;
+    font-weight: 300;
+    line-height: 1.4;
+    margin-bottom: 20px;
+    letter-spacing: 2px;
+}
+
+.hero-content p {
+    font-size: 18px;
+    margin-bottom: 30px;
+}
+
+.cta-button {
+    display: inline-block;
+    padding: 15px 40px;
+    background: #d4a574;
+    color: white;
+    text-decoration: none;
+    border-radius: 30px;
+    transition: background 0.3s;
+}
+
+.cta-button:hover {
+    background: #b8935f;
+}
+
+/* Sections */
+section {
+    padding: 80px 0;
+}
+
+.section-title {
+    text-align: center;
+    font-size: 36px;
+    font-weight: 300;
+    margin-bottom: 50px;
+    letter-spacing: 3px;
+    position: relative;
+    padding-bottom: 20px;
+}
+
+.section-title::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 50px;
+    height: 2px;
+    background: #d4a574;
+}
+
+/* Concept */
+.concept {
+    background: #f8f8f8;
+}
+
+.concept-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
+    align-items: center;
+}
+
+.concept-text h3 {
+    font-size: 28px;
+    margin-bottom: 20px;
+    color: #d4a574;
+}
+
+.concept-text p {
+    margin-bottom: 15px;
+    line-height: 1.8;
+}
+
+.concept-image img {
+    width: 100%;
+    border-radius: 10px;
+}
+
+/* Menu */
+.menu-tabs {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.tab-btn {
+    padding: 10px 30px;
+    background: transparent;
+    border: 2px solid #d4a574;
+    color: #d4a574;
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.tab-btn.active,
+.tab-btn:hover {
+    background: #d4a574;
+    color: white;
+}
+
+.menu-content {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+.menu-item {
+    padding: 20px;
+    border-bottom: 1px solid #eee;
+}
+
+.menu-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.menu-header h3 {
+    font-size: 20px;
+}
+
+.price {
+    font-size: 22px;
+    color: #d4a574;
+    font-weight: bold;
+}
+
+/* Style Gallery */
+.style-gallery {
+    background: #f8f8f8;
+}
+
+.style-filters {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    margin-bottom: 40px;
+}
+
+.filter-btn {
+    padding: 8px 20px;
+    background: white;
+    border: 1px solid #ddd;
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.filter-btn.active,
+.filter-btn:hover {
+    background: #d4a574;
+    color: white;
+    border-color: #d4a574;
+}
+
+.style-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.style-item {
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.style-item img {
+    width: 100%;
+    height: 400px;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.style-item:hover img {
+    transform: scale(1.1);
+}
+
+.style-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(to top, rgba(0,0,0,0.8), transparent);
+    color: white;
+    padding: 20px;
+    transform: translateY(100%);
+    transition: transform 0.3s;
+}
+
+.style-item:hover .style-overlay {
+    transform: translateY(0);
+}
+
+/* Staff */
+.staff-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 40px;
+}
+
+.staff-card {
+    text-align: center;
+    padding: 30px;
+    background: white;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
+    border-radius: 10px;
+}
+
+.staff-card img {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 20px;
+}
+
+.staff-card h3 {
+    font-size: 22px;
+    margin-bottom: 5px;
+}
+
+.staff-role {
+    color: #d4a574;
+    margin-bottom: 15px;
+}
+
+.staff-message {
+    color: #666;
+    margin-bottom: 20px;
+    line-height: 1.6;
+}
+
+.staff-sns a {
+    color: #d4a574;
+    text-decoration: none;
+}
+
+/* Instagram */
+.instagram {
+    background: #f8f8f8;
+}
+
+.instagram-id {
+    text-align: center;
+    font-size: 18px;
+    color: #666;
+    margin-bottom: 30px;
+}
+
+.instagram-feed {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 10px;
+}
+
+.instagram-feed img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: opacity 0.3s;
+}
+
+.instagram-feed img:hover {
+    opacity: 0.8;
+}
+
+/* Access */
+.access-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
+    align-items: start;
+}
+
+.access-info table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.access-info th {
+    text-align: left;
+    padding: 15px;
+    background: #f8f8f8;
+    width: 100px;
+}
+
+.access-info td {
+    padding: 15px;
+}
+
+.access-video {
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+
+.access-video iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+/* Booking */
+.booking {
+    background: linear-gradient(135deg, #d4a574 0%, #b8935f 100%);
+    color: white;
+}
+
+.booking .section-title {
+    color: white;
+}
+
+.booking .section-title::after {
+    background: white;
+}
+
+.booking-content {
+    text-align: center;
+}
+
+.booking-content p {
+    font-size: 18px;
+    margin-bottom: 30px;
+}
+
+.booking-button {
+    padding: 15px 50px;
+    background: white;
+    color: #d4a574;
+    border: none;
+    font-size: 18px;
+    border-radius: 30px;
+    cursor: pointer;
+    transition: transform 0.3s;
+}
+
+.booking-button:hover {
+    transform: scale(1.05);
+}
+
+.booking-note {
+    margin-top: 30px;
+    font-size: 14px;
+    opacity: 0.9;
+}
+
+/* Footer */
+.footer {
+    background: #333;
+    color: white;
+    padding: 50px 0 20px;
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+}
+
+.footer-logo span {
+    display: block;
+    letter-spacing: 2px;
+}
+
+.footer-links,
+.footer-social {
+    display: flex;
+    gap: 30px;
+}
+
+.footer-links a,
+.footer-social a {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+.footer-links a:hover,
+.footer-social a:hover {
+    color: #d4a574;
+}
+
+.copyright {
+    text-align: center;
+    padding-top: 30px;
+    border-top: 1px solid #555;
+    color: #999;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .header-inner {
+        flex-direction: column;
+        gap: 15px;
+    }
+    
+    .nav ul {
+        flex-direction: column;
+        text-align: center;
+        gap: 10px;
+    }
+    
+    .hero-content h1 {
+        font-size: 32px;
+    }
+    
+    .concept-content,
+    .access-content {
+        grid-template-columns: 1fr;
+    }
+    
+    .style-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .staff-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .footer-content {
+        flex-direction: column;
+        gap: 20px;
+    }
+}`,
+    js: `// タブ切り替え
+const tabBtns = document.querySelectorAll('.tab-btn');
+const tabContents = document.querySelectorAll('.tab-content');
+
+tabBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab;
+        
+        // タブボタンのアクティブ状態を切り替え
+        tabBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        
+        // タブコンテンツの表示を切り替え
+        tabContents.forEach(content => {
+            content.classList.remove('active');
+            if (content.id === tab) {
+                content.classList.add('active');
+            }
+        });
+    });
+});
+
+// スタイルギャラリーのフィルター
+const filterBtns = document.querySelectorAll('.filter-btn');
+const styleItems = document.querySelectorAll('.style-item');
+
+filterBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+        const filter = btn.dataset.filter;
+        
+        // ボタンのアクティブ状態を切り替え
+        filterBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        
+        // アイテムの表示を切り替え
+        styleItems.forEach(item => {
+            if (filter === 'all' || item.dataset.category === filter) {
+                item.style.display = 'block';
+            } else {
+                item.style.display = 'none';
+            }
+        });
+    });
+});
+
+// スムーズスクロール
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function (e) {
+        e.preventDefault();
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+            const headerHeight = document.querySelector('.header').offsetHeight;
+            const targetPosition = target.offsetTop - headerHeight;
+            window.scrollTo({
+                top: targetPosition,
+                behavior: 'smooth'
+            });
+        }
+    });
+});
+
+// 予約ボタン
+document.querySelector('.booking-button').addEventListener('click', () => {
+    alert('予約システムへ移動します（実装予定）');
+});
+
+// ヘッダー背景の変更
+window.addEventListener('scroll', () => {
+    const header = document.querySelector('.header');
+    if (window.scrollY > 100) {
+        header.style.background = 'rgba(255, 255, 255, 1)';
+    } else {
+        header.style.background = 'rgba(255, 255, 255, 0.98)';
+    }
+});`
+  }
+}

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -1,9 +1,13 @@
 import { WebTemplate } from './types'
 import { cafeModernTemplate } from './data/cafe-modern'
 import { cafeVintageTemplate } from './data/cafe-vintage'
+import { cafeMinimalTemplate } from './data/cafe-minimal'
 import { retailFashionTemplate } from './data/retail-fashion'
+import { retailGeneralTemplate } from './data/retail-general'
 import { restaurantJapaneseTemplate } from './data/restaurant-japanese'
+import { restaurantWesternTemplate } from './data/restaurant-western'
 import { serviceClinicTemplate } from './data/service-clinic'
+import { serviceBeautyTemplate } from './data/service-beauty'
 import { portfolioFreelanceTemplate } from './data/portfolio-freelance'
 
 /**
@@ -12,9 +16,13 @@ import { portfolioFreelanceTemplate } from './data/portfolio-freelance'
 export const templates: WebTemplate[] = [
   cafeModernTemplate,
   cafeVintageTemplate,
+  cafeMinimalTemplate,
   retailFashionTemplate,
+  retailGeneralTemplate,
   restaurantJapaneseTemplate,
+  restaurantWesternTemplate,
   serviceClinicTemplate,
+  serviceBeautyTemplate,
   portfolioFreelanceTemplate
 ]
 


### PR DESCRIPTION
## Summary
- 既存テンプレートに画像とYouTube動画を追加
- 新規テンプレート4個追加（合計10個に）
- 初心者向けWeb制作学習ガイドページを作成
- レスポンシブ対応とUIの改善

## 実装内容

### 🎨 テンプレートの改善
- **画像追加**: UnsplashのフリーイメージをすべてのテンプレートI CORPORATEに組み込み
- **動画埋め込み**: YouTubeのiframeを適切な箇所に追加
- **レスポンシブ改善**: スマホ表示時のメニューとレイアウトを最適化
- **ホバーエフェクト**: 画像にトランジション効果を追加

### 📚 新規テンプレート（4個追加）
1. **カフェ - ミニマル**: シンプルで洗練されたミニマルデザイン
2. **小売店 - 雑貨**: Instagram連携、ブログ機能付き
3. **レストラン - 洋食**: 高級感のあるフレンチ/イタリアン向け
4. **サービス業 - 美容室**: スタイルギャラリー、スタッフ紹介付き

### 📖 学習ガイドページ (/note/webpage-temp/guide)
- **Step 1**: ファイル作成から表示確認まで
- **Step 2**: 色のカスタマイズ方法
- **Step 3**: テキストと画像の変更
- **Step 4**: レイアウト調整
- **開発のコツ**: ツール紹介、よくあるミス、デバッグ方法
- **次のステップ**: 学習リソースと公開方法

### 🔗 UI改善
- 各テンプレート詳細ページから学習ガイドへのリンク追加
- 学習ガイドは初心者に優しい説明とビジュアルで構成
- 外部リソース（MDN、Unsplash、Figma等）へのリンク追加

## Test plan
- [x] ビルドエラーなし（npm run build）
- [x] 全10個のテンプレートが正常に表示
- [x] 画像とYouTube動画が適切に表示
- [x] レスポンシブデザインが機能（スマホ・タブレット）
- [x] 学習ガイドページが正常に表示
- [x] すべての内部リンクが機能
- [x] プレビュー機能でテンプレートが正しく表示

## Screenshots
### テンプレート数が10個に増加
- カフェ x3、小売店 x2、レストラン x2、サービス業 x2、ポートフォリオ x1

### 学習ガイド
- 初心者でも分かりやすいステップバイステップの説明
- コード例とビジュアルガイド付き

🤖 Generated with [Claude Code](https://claude.ai/code)