### PR TITLE
feat: ブログ記事にスクロールトップボタンを追加

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { getAllPostSlugs, getPostData } from '@/lib/posts'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
+import ScrollToTopButton from '@/components/ScrollToTopButton'
 
 // 各記事の詳細ページのviewファイルです。
 
@@ -59,6 +60,7 @@ export default async function BlogPostPage(props: any) {
           記事一覧へ →
         </Link>
       </nav>
+      <ScrollToTopButton />
     </div>
   )
 }

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      // 300px以上スクロールしたらボタンを表示
+      if (window.scrollY > 300) {
+        setIsVisible(true)
+      } else {
+        setIsVisible(false)
+      }
+    }
+
+    window.addEventListener('scroll', toggleVisibility)
+
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility)
+    }
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    })
+  }
+
+  return (
+    <>
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-6 right-6 z-50 bg-blue-600 hover:bg-blue-700 text-white rounded-full p-3 shadow-lg transition-all duration-300 hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          aria-label="ページトップへ戻る"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 10l7-7m0 0l7 7m-7-7v18"
+            />
+          </svg>
+        </button>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## 概要
ブログ記事ページに「トップに戻る」ボタンを追加しました。

## 変更内容

### 🎯 新機能
- **スクロールトップボタンコンポーネント** (`ScrollToTopButton.tsx`)
  - 300px以上スクロール時に表示
  - 右下に固定配置（PC・SP両対応）
  - スムーススクロールアニメーション
  - アクセシビリティ対応

### 📝 変更ファイル
1. `src/components/ScrollToTopButton.tsx` - 新規作成
2. `src/app/blog/[slug]/page.tsx` - コンポーネントの追加

## デザイン仕様
- **配置**: 画面右下に固定（bottom: 24px, right: 24px）
- **サイズ**: 48x48px の円形ボタン
- **色**: 青色（bg-blue-600）、ホバー時に濃い青（bg-blue-700）
- **アニメーション**: ホバー時に1.1倍に拡大
- **表示条件**: 300px以上スクロール時のみ表示

## スクリーンショット（イメージ）
```
[記事コンテンツ]
        ...
        ...
        ...
                    [↑] <- スクロールトップボタン
```

## テスト内容
- ✅ スクロール時の表示/非表示
- ✅ クリック時のスムーススクロール
- ✅ レスポンシブ対応（PC/SP）
- ✅ アクセシビリティ（キーボード操作、スクリーンリーダー）

🤖 Generated with [Claude Code](https://claude.ai/code)