### PR TITLE
_posts/配下の記事をposts/配下に移行

### DIFF
--- a/posts/0043_rails-partial-basics.md
+++ b/posts/0043_rails-partial-basics.md
@@ -1,0 +1,342 @@
+---
+id: 43
+title: "Rails初心者が混乱しがちなパーシャル（部分テンプレート）の命名ルールと使い方"
+tags: ["Rails", "View", "Template", "Partial", "HAML"]
+create: "2025-09-05 00:28"
+update: "2025-09-05 03:21"
+---
+
+# Rails初心者が混乱しがちなパーシャル（部分テンプレート）の命名ルールと使い方
+
+Railsでビューを作成していると必ず出会うのが「パーシャル（部分テンプレート）」です。しかし、初心者の方が最も混乱しやすいのが**ファイル名の命名ルール**です。
+
+「なぜファイル名にはアンダースコア（`_`）が必要なのに、呼び出す時は外すの？」という疑問を持ったことがある方も多いのではないでしょうか。
+
+この記事では、Railsのパーシャルの基本的な使い方から、混乱しがちな命名ルールまでを初心者向けに詳しく解説します。
+
+## パーシャルとは何か？
+
+パーシャル（Partial）は、**再利用可能な部分テンプレート**のことです。Webコンポーネントのような感覚で、ビューの一部を切り出して別ファイルに保存し、複数の場所から呼び出すことができます。
+
+### パーシャルのメリット
+
+- **再利用性**: 一度作れば複数の場所で使える
+- **保守性**: パーシャル1つを修正すれば全箇所に反映される
+- **可読性**: メインのビューがスッキリして読みやすくなる
+- **一貫性**: 同じ見た目・動作を保証できる
+
+## パーシャルの基本的な使い方
+
+### 1. パーシャルファイルの作成
+
+パーシャルファイルは**必ずアンダースコア（`_`）から始める**必要があります。
+
+```
+app/views/users/
+├── index.html.erb          # 通常のビューファイル
+├── show.html.erb           # 通常のビューファイル
+├── _profile.html.erb       # パーシャルファイル
+└── _navigation.html.erb    # パーシャルファイル
+```
+
+### 2. パーシャルの呼び出し
+
+パーシャルを呼び出す際は、**アンダースコアを外して**`render`メソッドを使います。
+
+```erb
+<!-- app/views/users/index.html.erb -->
+<h1>ユーザー一覧</h1>
+<%= render 'navigation' %>  <!-- _navigation.html.erb を呼び出し -->
+
+<div class="users-list">
+  <% @users.each do |user| %>
+    <%= render 'profile', user: user %>  <!-- _profile.html.erb を呼び出し -->
+  <% end %>
+</div>
+```
+
+### 3. パーシャルでのデータの受け渡し
+
+パーシャルにデータを渡すには、`locals`オプションまたは直接指定します。
+
+```erb
+<!-- 方法1: localsオプションを使用 -->
+<%= render 'profile', locals: { user: @user, show_email: true } %>
+
+<!-- 方法2: 直接指定（推奨） -->
+<%= render 'profile', user: @user, show_email: true %>
+```
+
+```erb
+<!-- _profile.html.erb -->
+<div class="user-profile">
+  <h3><%= user.name %></h3>
+  <% if show_email %>
+    <p>Email: <%= user.email %></p>
+  <% end %>
+</div>
+```
+
+## なぜアンダースコアが必要なのか？
+
+### ファイルの種類を区別するため
+
+Railsでは**ファイルの種類を一目で判別**できるよう、以下のような命名規則があります。
+
+| ファイルの種類 | 命名例 | 用途 |
+|---|---|---|
+| **通常のビュー** | `index.html.erb` | 独立したページとして表示 |
+| **パーシャル** | `_profile.html.erb` | 部品として他から呼び出される |
+| **レイアウト** | `application.html.erb` | ページ全体の枠組み |
+
+### Convention over Configuration
+
+これはRailsの基本思想である「[Convention over Configuration](https://ja.wikipedia.org/wiki/Convention_over_Configuration)（設定より規約）」の一例です。
+
+- **設定ファイルで細かく指定する**のではなく
+- **命名規則に従うことで自動的に動作する**ようにする
+
+この思想により、開発者は設定ファイルを書く手間を省き、コードを書くことに集中できます。
+
+## よくある間違いとその対処法
+
+### ❌ 間違いパターン1: renderでアンダースコアを付けてしまう
+
+```erb
+<!-- 間違い -->
+<%= render '_profile' %>
+<%= render '_navigation' %>
+<%= render 'shared/_header' %>
+```
+
+```erb
+<!-- 正しい -->
+<%= render 'profile' %>
+<%= render 'navigation' %>
+<%= render 'shared/header' %>
+```
+
+### ❌ 間違いパターン2: ファイル名にアンダースコアを付け忘れる
+
+```
+<!-- 間違い -->
+app/views/users/profile.html.erb
+
+<!-- 正しい -->
+app/views/users/_profile.html.erb
+```
+
+### エラーメッセージの読み方
+
+アンダースコアを付け忘れたり、間違った呼び出しをすると以下のようなエラーが表示されます。
+
+```
+ActionView::MissingTemplate: Missing partial users/_profile
+```
+
+このエラーメッセージのポイント：
+- **`Missing partial`**: パーシャルが見つからない
+- **`users/_profile`**: 探しているファイルは `app/views/users/_profile.html.erb`
+- エラーメッセージには**アンダースコア付き**で表示されるが、renderでは**アンダースコアなし**で書く
+
+## パーシャルファイルから他のパーシャルを呼び出す
+
+パーシャルファイル内でも、他のパーシャルを呼び出すことができます。
+
+```erb
+<!-- _user_card.html.erb -->
+<div class="user-card">
+  <%= render 'user_avatar', user: user %>     <!-- _user_avatar.html.erb -->
+  <%= render 'user_details', user: user %>    <!-- _user_details.html.erb -->
+  <%= render 'user_actions', user: user %>    <!-- _user_actions.html.erb -->
+</div>
+```
+
+このように、**パーシャルを小さな部品に分割**することで、より保守性の高いコードを書くことができます。
+
+## 別ディレクトリのパーシャルを呼び出す
+
+パーシャルは別のディレクトリからも呼び出すことができます。
+
+### ディレクトリ構造例
+
+```
+app/views/
+├── shared/
+│   ├── _header.html.erb
+│   ├── _footer.html.erb
+│   └── _sidebar.html.erb
+├── users/
+│   ├── index.html.erb
+│   └── _profile.html.erb
+└── admin/
+    ├── index.html.erb
+    └── _dashboard.html.erb
+```
+
+### 呼び出し方法
+
+```erb
+<!-- app/views/users/index.html.erb から -->
+<%= render 'shared/header' %>          <!-- app/views/shared/_header.html.erb -->
+<%= render 'profile', user: @user %>   <!-- app/views/users/_profile.html.erb -->
+
+<!-- app/views/admin/index.html.erb から -->
+<%= render 'shared/header' %>          <!-- app/views/shared/_header.html.erb -->
+<%= render 'users/profile', user: @user %>  <!-- app/views/users/_profile.html.erb -->
+```
+
+## パーシャルのファイル検索順序
+
+Railsは以下の順序でパーシャルファイルを検索します。
+
+1. **同じディレクトリ**: `app/views/users/_profile.html.erb`
+2. **共通ディレクトリ**: `app/views/application/_profile.html.erb`
+3. **その他のビューパス**
+
+この検索順序により、特定のコントローラー専用のパーシャルがある場合はそれを優先し、なければ共通のパーシャルを使用するという柔軟な運用が可能です。
+
+## 実践的な使用例
+
+### ナビゲーションメニューの共通化
+
+```erb
+<!-- app/views/shared/_navigation.html.erb -->
+<nav class="main-navigation">
+  <ul>
+    <li><%= link_to 'ホーム', root_path %></li>
+    <li><%= link_to 'ユーザー', users_path %></li>
+    <li><%= link_to 'お問い合わせ', contact_path %></li>
+  </ul>
+</nav>
+```
+
+```erb
+<!-- app/views/layouts/application.html.erb -->
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- head要素の内容 -->
+</head>
+<body>
+  <%= render 'shared/navigation' %>
+  
+  <main>
+    <%= yield %>
+  </main>
+  
+  <%= render 'shared/footer' %>
+</body>
+</html>
+```
+
+### フォーム部品の再利用
+
+```erb
+<!-- app/views/users/_form.html.erb -->
+<%= form_with model: user do |form| %>
+  <div class="form-group">
+    <%= form.label :name, '名前' %>
+    <%= form.text_field :name, class: 'form-control' %>
+  </div>
+  
+  <div class="form-group">
+    <%= form.label :email, 'メールアドレス' %>
+    <%= form.email_field :email, class: 'form-control' %>
+  </div>
+  
+  <%= form.submit class: 'btn btn-primary' %>
+<% end %>
+```
+
+```erb
+<!-- app/views/users/new.html.erb -->
+<h1>新規ユーザー登録</h1>
+<%= render 'form', user: @user %>
+
+<!-- app/views/users/edit.html.erb -->
+<h1>ユーザー情報編集</h1>
+<%= render 'form', user: @user %>
+```
+
+## 覚え方のコツ
+
+### 1. ファイル名の構成を理解する
+
+```
+実際のファイル名: app/views/shared/_header.html.erb
+                  ↑       ↑     ↑    ↑      ↑
+                  パス    種別  名前  形式   言語
+```
+
+- **パス**: `app/views/shared/`
+- **種別**: `_` (パーシャルを示す)
+- **名前**: `header`
+- **形式**: `.html`
+- **言語**: `.erb`
+
+### 2. renderで書く内容
+
+```ruby
+render 'shared/header'
+       ↑      ↑
+       パス   名前（アンダースコアと拡張子は自動で付加）
+```
+
+Railsが自動で補完してくれる部分：
+- `app/views/` ← 自動で付く
+- `_` ← 自動で付く
+- `.html.erb` ← 自動で付く
+
+### 3. 「部品には印を付ける」と覚える
+
+- **部品（パーシャル）**: `_`という印を付ける
+- **完成品（通常ビュー）**: 印は付けない
+
+## HAMLでの使用方法
+
+ERBの例をHAML記法で書くと以下のようになります。
+
+```haml
+-# app/views/users/index.html.haml
+%h1 ユーザー一覧
+= render 'navigation'
+
+.users-list
+  - @users.each do |user|
+    = render 'profile', user: user
+```
+
+```haml
+-# app/views/users/_profile.html.haml
+.user-profile
+  %h3= user.name
+  - if show_email
+    %p= "Email: #{user.email}"
+```
+
+## まとめ
+
+Railsのパーシャルは、以下のルールを覚えておけば安心して使えます。
+
+### 📝 重要なルール
+
+1. **ファイル名**: 必ずアンダースコア（`_`）で始める
+2. **呼び出し**: `render`でアンダースコアを外して指定
+3. **データ渡し**: カンマ区切りでローカル変数を渡せる
+4. **ネスト**: パーシャルから他のパーシャルも呼び出せる
+
+### 🎯 覚え方のポイント
+
+- **ファイル名 = 印付きの部品**
+- **render = 印を外して呼び出し**
+- **エラーメッセージには印付きで表示されるが、書くときは印なし**
+
+パーシャルを効果的に使うことで、保守性が高く読みやすいRailsアプリケーションを作ることができます。最初は混乱するかもしれませんが、慣れてしまえば非常に強力な機能です。
+
+ぜひ実際のプロジェクトでパーシャルを使って、よりクリーンなビューコードを書いてみてください！
+
+## 参考リンク
+
+- [Rails Guides - レイアウトとレンダリング](https://railsguides.jp/layouts_and_rendering.html)
+- [Rails API Documentation - ActionView::PartialRenderer](https://api.rubyonrails.org/classes/ActionView/PartialRenderer.html)

--- a/posts/0044_rails-architecture-design-principles.md
+++ b/posts/0044_rails-architecture-design-principles.md
@@ -1,0 +1,797 @@
+---
+id: 44
+title: "「1ファイルで済む」vs「正しい設計」- Railsアーキテクチャ原則が教える本当の価値"
+tags: ["Rails", "Architecture", "Design", "MVC", "Best Practices", "Refactoring"]
+create: "2025-09-05 01:58"
+update: "2025-09-05 03:21"
+---
+
+# 「1ファイルで済む」vs「正しい設計」- Railsアーキテクチャ原則が教える本当の価値
+
+開発現場でよく聞く言葉があります。
+
+「この修正、1ファイル変更するだけで済むから簡単でしょ？」
+
+確かに、短期的には修正量が少なく見えます。しかし、**本当に「簡単」なのでしょうか？**
+
+この記事では、実際のWeb・アプリ共通の通知機能実装を例に、「修正量を小さく納める方法」と「Railsのアーキテクチャ原則に従った方法」を比較し、なぜ後者の方が長期的に価値があるのかを詳しく解説します。
+
+## この記事で学べること（TL;DR）
+
+- ✅ **「1ファイル修正」のアプローチがなぜ長期的に問題となるか**
+- ✅ **Railsアーキテクチャ原則（Single Source of Truth、Separation of Concerns等）の実践的価値**
+- ✅ **設計投資の定量的な効果（6ヶ月で14時間削減の実例）**
+- ✅ **チーム開発でのメンテナンス性向上とバグ削減手法**
+
+## 前提：実装すべき機能
+
+WEB版とスマートフォンアプリで**発送遅延通知を統一表示**する機能を実装する必要があります。
+
+### 要件
+- **WEB側**: Railsビューで通知を表示
+- **APP側**: React Native経由でAPIから取得して表示
+- **表示条件**: 同じフラグで制御
+- **表示内容**: 同じテキストを使用
+- **運用性**: 設定変更を容易に
+
+この要件に対して、2つのアプローチが考えられます。
+
+## アプローチ1: 「1ファイル修正」で済ます方法
+
+### 実装方法
+```ruby
+# app/controllers/api/app/v1/metadata_controller.rb（既存ファイル）
+class Api::App::V1::MetadataController < Api::App::V1::ApplicationController
+  def show
+    render json: { 
+      minimumAppVersion: Device::MINIMUM_APP_VERSION,
+      showShippingNotice: true,  # ← 直接書く
+      shippingNoticeText: "現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。順次発送を進めております。お客様には大変なご不便とご心配をおかけし、申し訳ございません。"  # ← 直接書く
+    }
+  end
+end
+```
+
+```haml
+<!-- app/views/shared/_shipping_notice.html.haml（既存ファイル） -->
+.shipping-notice
+  現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。順次発送を進めております。お客様には大変なご不便とご心配をおかけし、申し訳ございません。
+```
+
+### メリット
+- **修正箇所が少ない**: 2ファイルのみの変更
+- **即座に実装完了**: 設定ファイルやクラス作成が不要
+- **理解しやすい**: 値がどこに書かれているか一目瞭然
+
+### デメリット（後から判明）
+しかし、運用が始まると問題が見えてきます：
+
+#### 1. **同期の困難さ**
+```ruby
+# APIコントローラー
+showShippingNotice: true,
+shippingNoticeText: "現在、多くの発送申請を..."
+
+# ビューファイル  
+.shipping-notice
+  現在、多くの発送申請を... <!-- 微妙に文言が違う！ -->
+```
+
+#### 2. **変更時の手間**
+```ruby
+# テキスト変更時に必要な作業
+# 1. APIコントローラーを修正
+# 2. ビューファイルを修正  
+# 3. 両方が同じ内容か確認
+# 4. テスト実行
+# 5. デプロイ
+```
+
+#### 3. **緊急時の対応困難**
+```ruby
+# 緊急でON/OFF切り替えたい場合
+# → コード修正 → デプロイが必要
+# → 数時間〜半日かかる
+```
+
+## アプローチ2: Railsアーキテクチャ原則に従う方法
+
+### 設計思想
+
+Railsのアーキテクチャ原則に従い、以下を重視します：
+
+1. **Single Source of Truth（単一情報源の原則）**
+2. **Separation of Concerns（関心の分離）**
+3. **Convention over Configuration（設定より規約）**
+4. **Fat Model, Skinny Controller**
+
+### 実装ステップ
+
+#### ステップ1: 通知設定の専用クラス作成
+
+```ruby
+# app/lib/notification_config.rb（新規作成）
+class NotificationConfig
+  # 発送遅延通知
+  module ShippingDelay
+    ENABLED = true
+    TEXT = '現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。順次発送を進めております。お客様には大変なご不便とご心配をおかけし、申し訳ございません。'
+  end
+
+  # 将来的な拡張用
+  module Maintenance
+    ENABLED = false
+    TEXT = 'システムメンテナンスのため、一部機能がご利用いただけません。'
+  end
+
+  module Campaign
+    ENABLED = false
+    TEXT = '期間限定キャンペーン実施中！'
+  end
+end
+```
+
+**なぜ `app/lib/` なのか？**
+
+| ディレクトリ | 用途 | 今回の設定に適用？ |
+|---|---|---|
+| `app/models/` | ActiveRecordモデル（DB関連） | ❌ DBテーブルではない |
+| `app/controllers/` | リクエスト処理 | ❌ HTTP処理ではない |
+| `app/lib/` | アプリ固有のライブラリ | ✅ **最適** |
+| `lib/` | 汎用ライブラリ | △ アプリ固有なので微妙 |
+
+**Rails自動読み込み**: Rails 6以降、`app/lib/`は`config.autoload_paths`に含まれるため、追加設定なしでクラスが自動読み込みされます。
+
+#### ステップ2: APIコントローラーの修正
+
+```ruby
+# app/controllers/api/app/v1/metadata_controller.rb
+class Api::App::V1::MetadataController < Api::App::V1::ApplicationController
+  def show
+    render json: { 
+      minimumAppVersion: Device::MINIMUM_APP_VERSION,
+      showShippingNotice: NotificationConfig::ShippingDelay::ENABLED,
+      shippingNoticeText: NotificationConfig::ShippingDelay::TEXT
+    }
+  end
+end
+```
+
+#### ステップ3: WEB側の適切な実装
+
+**❌ 良くない実装例**
+```haml
+<!-- ビューでビジネスロジックを持つのは適切ではない -->
+- if NotificationConfig::ShippingDelay::ENABLED
+  .shipping-notice
+    = NotificationConfig::ShippingDelay::TEXT
+```
+
+**✅ 適切な実装例**
+```ruby
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  # サイト全体で必要な場合はbefore_actionが有効
+  before_action :set_shipping_notification
+  
+  private
+  
+  def set_shipping_notification
+    @shipping_notice_enabled = NotificationConfig::ShippingDelay::ENABLED
+    @shipping_notice_text = NotificationConfig::ShippingDelay::TEXT
+  end
+  
+  # 特定のページでのみ使用する場合の代替方法
+  # helper_method :shipping_notice_enabled?, :shipping_notice_text
+  
+  # def shipping_notice_enabled?
+  #   NotificationConfig::ShippingDelay::ENABLED
+  # end
+  
+  # def shipping_notice_text
+  #   NotificationConfig::ShippingDelay::TEXT
+  # end
+end
+```
+
+```haml
+<!-- app/views/shared/_shipping_notice.html.haml -->
+- if @shipping_notice_enabled
+  .shipping-notice
+    = @shipping_notice_text
+```
+
+#### ステップ4: テストの更新
+
+```ruby
+# spec/requests/api/app/v1/metadata_controller_spec.rb
+RSpec.describe Api::App::V1::MetadataController do
+  describe 'GET #show' do
+    context '発送通知が有効な場合' do
+      before do
+        stub_const('NotificationConfig::ShippingDelay::ENABLED', true)
+        stub_const('NotificationConfig::ShippingDelay::TEXT', 'テスト用メッセージ')
+      end
+
+      it '適切なレスポンスを返す' do
+        get api_app_v1_metadata_path
+        json = JSON.parse(response.body)
+        expect(json['showShippingNotice']).to be_truthy
+        expect(json['shippingNoticeText']).to eq('テスト用メッセージ')
+      end
+    end
+  end
+end
+```
+
+### 修正が必要なファイル数
+
+```
+新規作成: 1ファイル
+├── app/lib/notification_config.rb
+
+修正: 4ファイル  
+├── app/controllers/api/app/v1/metadata_controller.rb
+├── app/controllers/application_controller.rb
+├── app/views/shared/_shipping_notice.html.haml
+└── spec/requests/api/app/v1/metadata_controller_spec.rb
+
+合計: 5ファイル
+```
+
+## 2つのアプローチの詳細比較
+
+### 開発時の工数
+
+| 項目 | 1ファイル修正 | アーキテクチャ原則 |
+|---|---|---|
+| **実装時間** | 30分 | 2時間 |
+| **修正ファイル数** | 2個 | 5個 |
+| **テスト作成** | 簡単 | やや複雑 |
+| **レビュー時間** | 短い | 長い |
+
+一見すると、1ファイル修正の方が効率的に見えます。
+
+### 運用時の違い
+
+しかし、**運用フェーズ**に入ると状況は一変します：
+
+#### シナリオ1: テキスト変更
+
+**1ファイル修正の場合**
+```bash
+# 作業手順（40分）
+1. APIコントローラー修正（5分）
+2. ビューファイル修正（5分）
+3. 内容の同期確認（10分）
+4. テスト実行（10分）
+5. デプロイ（10分）
+```
+
+**アーキテクチャ原則の場合**
+```bash
+# 作業手順（15分）
+1. NotificationConfig修正（5分）
+2. テスト実行（5分）  
+3. デプロイ（5分）
+```
+
+#### シナリオ2: 緊急でON/OFF切り替え
+
+**1ファイル修正の場合**
+```ruby
+# 各ファイルを個別に修正が必要
+# APIコントローラー
+showShippingNotice: false,  # ← 手動変更
+
+# ビューファイル
+- if false  # ← 手動変更（しかもこれだと見た目が悪い）
+```
+
+**アーキテクチャ原則の場合**
+```ruby
+# 1箇所変更するだけ
+module ShippingDelay
+  ENABLED = false  # ← この1行だけ
+  TEXT = '...'
+end
+```
+
+#### シナリオ3: 新しい通知追加
+
+**1ファイル修正の場合**
+```ruby
+# 各ファイルにバラバラに追加
+# APIコントローラー
+showMaintenanceNotice: true,
+maintenanceNoticeText: "...",
+
+# ビューファイル（別ファイルに）
+- if true
+  .maintenance-notice
+    メンテナンス中...
+```
+
+**アーキテクチャ原則の場合**
+```ruby
+# 設定クラスに追加するだけ
+module Maintenance
+  ENABLED = true
+  TEXT = 'メンテナンス中...'
+end
+
+# 使用箇所では統一的に参照
+NotificationConfig::Maintenance::ENABLED
+NotificationConfig::Maintenance::TEXT
+```
+
+### 長期的なコスト分析
+
+#### 6ヶ月間の運用コスト（仮定）
+
+**1ファイル修正の場合**
+```
+初期実装: 0.5時間
+テキスト変更（月2回）: 1.3時間 × 6ヶ月 = 7.8時間
+ON/OFF切替（月1回）: 0.7時間 × 6ヶ月 = 4.2時間  
+新通知追加（2回）: 2時間 × 2回 = 4時間
+バグ修正（同期ミス等）: 3時間
+------
+合計: 約20時間
+```
+
+**アーキテクチャ原則の場合**
+```
+初期実装: 2時間
+テキスト変更（月2回）: 0.25時間 × 6ヶ月 = 1.5時間
+ON/OFF切替（月1回）: 0.1時間 × 6ヶ月 = 0.6時間
+新通知追加（2回）: 0.5時間 × 2回 = 1時間
+バグ修正: 0.5時間
+------
+合計: 約6時間
+```
+
+**結果**: 6ヶ月で**14時間（約2日分）の差**が生まれます。
+
+**注意**: この数値は仮定に基づく例であり、実際の数値はプロジェクトの変更頻度やチーム規模に依存します。しかし、数値化しにくい**定性的な価値**（開発者のストレス軽減、バグ修正の迅速化、新規メンバーのオンボーディング効率化など）も含めると、実際の価値はさらに大きくなります。
+
+## Railsアーキテクチャ原則の具体的価値
+
+### 1. Single Source of Truth（単一情報源の原則）
+
+**問題**: 同じ情報が複数箇所に散らばっている
+```ruby
+# ❌ 情報が分散
+# APIコントローラー
+shippingNoticeText: "現在、多くの発送申請を..."
+
+# ビューファイル  
+.notice 現在、多くの発送申請を...
+
+# 設定ファイル
+SHIPPING_NOTICE = "現在、多くの発送申請を..."
+```
+
+**解決**: 情報源を1箇所に集約
+```ruby
+# ✅ 単一情報源
+class NotificationConfig
+  module ShippingDelay
+    TEXT = '現在、多くの発送申請を...'  # ← ここだけ
+  end
+end
+
+# どこからでもこの値を参照
+NotificationConfig::ShippingDelay::TEXT
+```
+
+### 2. Separation of Concerns（関心の分離）
+
+各コンポーネントが適切な責務を持つように設計します：
+
+| コンポーネント | 責務 | 担当しないこと |
+|---|---|---|
+| **NotificationConfig** | 通知設定の管理 | HTTP処理、DB操作 |
+| **Controller** | リクエスト処理、データ準備 | 設定値の決定、ビューロジック |
+| **View** | 表示 | データ取得、ビジネスロジック |
+
+**❌ 関心が混在した例**
+```haml
+<!-- ビューでビジネスロジックを持っている -->
+- if Rails.env.production? && Time.current.hour.between?(9, 17)
+  - if some_complex_condition && user_has_permission?
+    .notice 現在、多くの発送申請を...
+```
+
+**✅ 適切に分離した例**
+```ruby
+# NotificationConfig: 設定管理
+module ShippingDelay
+  ENABLED = true
+end
+
+# Controller: データ準備
+@shipping_notice_enabled = NotificationConfig::ShippingDelay::ENABLED
+
+# View: 表示のみ
+- if @shipping_notice_enabled
+  .notice= @shipping_notice_text
+```
+
+### 3. Convention over Configuration（設定より規約）
+
+Railsの命名規約に従うことで、設定ファイルを最小化：
+
+```ruby
+# ディレクトリ構造がRailsの規約に従う
+app/
+├── lib/                    # アプリ固有ライブラリ
+│   └── notification_config.rb
+├── controllers/
+│   └── application_controller.rb
+└── views/
+    └── shared/
+        └── _shipping_notice.html.haml
+
+# クラス名も規約に従う  
+NotificationConfig::ShippingDelay::ENABLED
+```
+
+### 4. Fat Model, Skinny Controller
+
+ビジネスロジックをモデル層に集約する原則です。ここでいう「Model」とは、データベースとやりとりするActiveRecordモデルだけでなく、**アプリケーションのビジネスロジックを担当する`app/lib`内のクラスなども含めた広い意味**で捉えています：
+
+**❌ コントローラーが太い例**
+```ruby
+class MetadataController < ApplicationController
+  def show
+    # コントローラーでビジネスロジックを持っている
+    show_notice = if Rails.env.production?
+                    Time.current.between?(business_hours_start, business_hours_end)
+                  else
+                    true
+                  end
+    
+    notice_text = if special_campaign_active?
+                    "特別キャンペーン中！配送遅延のお知らせ"
+                  else
+                    "現在、多くの発送申請を..."
+                  end
+    
+    render json: {
+      showShippingNotice: show_notice,
+      shippingNoticeText: notice_text
+    }
+  end
+end
+```
+
+**✅ 適切に分離した例**
+```ruby
+# app/lib/notification_config.rb（ロジック集約）
+class NotificationConfig
+  module ShippingDelay
+    def self.enabled?
+      return true unless Rails.env.production?
+      Time.current.between?(business_hours_start, business_hours_end)
+    end
+    
+    def self.text
+      if special_campaign_active?
+        "特別キャンペーン中！配送遅延のお知らせ"
+      else
+        "現在、多くの発送申請を..."
+      end
+    end
+  end
+end
+
+# app/controllers/metadata_controller.rb（薄い）
+class MetadataController < ApplicationController
+  def show
+    render json: {
+      showShippingNotice: NotificationConfig::ShippingDelay.enabled?,
+      shippingNoticeText: NotificationConfig::ShippingDelay.text
+    }
+  end
+end
+```
+
+## 実装の進化過程
+
+### フェーズ1: 最小実装
+```ruby
+# シンプルな定数から開始
+module ShippingDelay
+  ENABLED = true
+  TEXT = '現在、多くの発送申請を...'
+end
+```
+
+### フェーズ2: 柔軟性の追加
+```ruby
+# メソッド化で動的な制御を実現
+# 注意：モジュール内でクラスメソッドを定義する際は def self.method_name を使用
+module ShippingDelay
+  def self.enabled?
+    Rails.env.production? ? ENV['SHOW_SHIPPING_NOTICE'] == 'true' : true
+  end
+  
+  def self.text
+    ENV.fetch('SHIPPING_NOTICE_TEXT', default_text)
+  end
+  
+  private
+  
+  def self.default_text
+    '現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。'
+  end
+end
+```
+
+### フェーズ3: 高度な制御
+```ruby
+# 条件による切り替えロジック
+module ShippingDelay
+  def self.enabled?
+    return false unless base_enabled?
+    return false if maintenance_mode?
+    return false if business_hours_only? && !business_hours?
+    true
+  end
+  
+  def self.text
+    case current_situation
+    when :high_volume then high_volume_text
+    when :maintenance then maintenance_text  
+    else default_text
+    end
+  end
+end
+```
+
+## テストの書きやすさ
+
+### 1ファイル修正の場合
+
+```ruby
+# テストが複雑になりがち
+RSpec.describe MetadataController do
+  it '適切なレスポンスを返す' do
+    # 複数の箇所をモックする必要
+    allow(Rails).to receive(:env).and_return('production')
+    allow(Time).to receive(:current).and_return(business_time)
+    allow(ENV).to receive(:[]).with('SHOW_SHIPPING_NOTICE').and_return('true')
+    
+    get :show
+    # テストの本質的な部分
+  end
+end
+```
+
+### アーキテクチャ原則の場合
+
+```ruby
+# テストがシンプル
+RSpec.describe MetadataController do
+  it '適切なレスポンスを返す' do
+    # 設定クラスだけをモック
+    allow(NotificationConfig::ShippingDelay).to receive(:enabled?).and_return(true)
+    allow(NotificationConfig::ShippingDelay).to receive(:text).and_return('テスト用')
+    
+    get :show
+    # テストの本質的な部分
+  end
+end
+
+# 設定ロジックは別途独立してテスト
+RSpec.describe NotificationConfig::ShippingDelay do
+  describe '.enabled?' do
+    context '本番環境で営業時間内の場合' do
+      it 'trueを返す' do
+        # NotificationConfigのロジックのみをテスト
+      end
+    end
+  end
+end
+```
+
+## チーム開発での違い
+
+### コードレビューの観点
+
+**1ファイル修正の場合**
+```ruby
+# レビュー時の確認ポイント
+# ❌ 複数ファイルの整合性確認が必要
+# ❌ ハードコードされた値の妥当性判断が困難
+# ❌ 将来的な拡張性が見えない
+```
+
+**アーキテクチャ原則の場合**
+```ruby
+# レビュー時の確認ポイント  
+# ✅ 設定クラスの設計が適切か
+# ✅ 責務分離ができているか
+# ✅ テストケースが網羅されているか
+```
+
+### 新規メンバーのオンボーディング
+
+**1ファイル修正の場合**
+```ruby
+# 新規メンバーが理解すべきこと
+# - APIコントローラーのどこに設定があるか
+# - ビューファイルのどこに対応する表示があるか  
+# - 両者の同期を保つ方法
+# - テストでの確認方法
+```
+
+**アーキテクチャ原則の場合**
+```ruby
+# 新規メンバーが理解すべきこと
+# - NotificationConfigクラスの役割
+# - Railsのディレクトリ構造規約
+# → 規約に従っているので理解しやすい
+```
+
+## パフォーマンスへの影響
+
+### メモリ使用量
+
+**1ファイル修正の場合**
+```ruby
+# 各所で文字列を重複して持つ
+"現在、多くの発送申請を..."  # APIコントローラー内
+"現在、多くの発送申請を..."  # ビューファイル内
+"現在、多くの発送申請を..."  # テストファイル内
+```
+
+**アーキテクチャ原則の場合**  
+```ruby
+# 文字列は1箇所で定義、参照は定数
+NotificationConfig::ShippingDelay::TEXT  # 定数参照
+```
+
+### 実行速度
+
+両者に大きな違いはありませんが、設定クラスを使う場合：
+
+```ruby
+# 初回アクセス時にクラスがロード（数ms）
+# 以降はメモリ上の定数を参照（0.001ms未満）
+NotificationConfig::ShippingDelay::ENABLED
+```
+
+## 他の設計パターンとの比較
+
+### データベース設定パターン
+
+```ruby
+# app/models/notification_setting.rb
+class NotificationSetting < ApplicationRecord
+  # メリット: 管理画面から変更可能
+  # デメリット: DB負荷、複雑さ増加
+end
+```
+
+### 環境変数パターン
+
+```ruby
+# config/application.rb
+config.show_shipping_notice = ENV.fetch('SHOW_SHIPPING_NOTICE', 'true') == 'true'
+
+# メリット: デプロイなしで変更可能
+# デメリット: 環境変数管理の複雑さ
+```
+
+### 設定ファイルパターン
+
+```yaml
+# config/notifications.yml
+shipping_delay:
+  enabled: true
+  text: "現在、多くの発送申請を..."
+
+# メリット: YAML形式で管理しやすい  
+# デメリット: 動的な制御が困難
+```
+
+今回のケースでは、**設定の複雑さ**と**変更頻度**を考慮して`app/lib/`のクラス定数が最適でした。
+
+## まとめ：本当の「簡単さ」とは
+
+### 短期的視点 vs 長期的視点
+
+| 観点 | 1ファイル修正 | アーキテクチャ原則 |
+|---|---|---|
+| **初期実装** | 簡単 | やや複雑 |
+| **1回目の変更** | 簡単 | 簡単 |
+| **5回目の変更** | 面倒 | 簡単 |
+| **新機能追加** | 困難 | 簡単 |
+| **バグ発生率** | 高い | 低い |
+| **メンテナンス** | 困難 | 簡単 |
+
+### 真の「簡単さ」の定義
+
+**1ファイル修正の「簡単さ」**
+```
+簡単さ = 修正ファイル数の少なさ
+```
+
+**アーキテクチャ原則の「簡単さ」**
+```
+簡単さ = 理解しやすさ × 変更しやすさ × バグの少なさ
+```
+
+### 投資対効果の考え方
+
+```ruby
+# 初期コスト
+アーキテクチャ原則 = 1ファイル修正 + 1.5時間
+
+# しかし、運用コストで逆転
+# 6ヶ月後: アーキテクチャ原則の方が14時間削減
+# 1年後: さらに28時間削減
+# 2年後: さらに56時間削減
+```
+
+**結論**: 初期の1.5時間の投資で、年間56時間（約1週間）を節約できます。
+
+## 実践的なアドバイス
+
+### いつアーキテクチャ原則を適用すべきか
+
+**適用を推奨するケース**
+- ✅ 複数の場所で同じ情報を使用する
+- ✅ 将来的に設定項目が増える可能性がある
+- ✅ チーム開発で多くの人が触る
+- ✅ 長期運用が予定されている
+
+**1ファイル修正でも良いケース**
+- ✅ 完全に1回限りの実装
+- ✅ プロトタイプや検証目的
+- ✅ 非常に小さなチーム（1-2人）
+- ✅ 短期プロジェクト（1-2ヶ月）
+
+### 段階的な改善アプローチ
+
+プロジェクトの状況によっては、段階的に改善していく方法も有効です：
+
+```ruby
+# フェーズ1: まずは動かす（1ファイル修正）
+showShippingNotice: true
+
+# フェーズ2: 設定を外出し  
+showShippingNotice: SHIPPING_NOTICE_ENABLED
+
+# フェーズ3: 設定クラス作成
+showShippingNotice: NotificationConfig::ShippingDelay::ENABLED
+
+# フェーズ4: 動的制御追加
+showShippingNotice: NotificationConfig::ShippingDelay.enabled?
+```
+
+## 最後に
+
+「修正量を小さく納める」という考え方は、短期的には魅力的に見えます。しかし、**ソフトウェアの価値は長期的な運用で決まります**。
+
+Railsのアーキテクチャ原則は、数多くの開発者の経験から生まれた知恵の結晶です。これらの原則に従うことで、以下を実現できます：
+
+1. **予測可能なコード**: 規約に従うことで、コードの在り処が予想できる
+2. **変更に強い設計**: 要件変更に対して柔軟に対応できる
+3. **チーム開発の効率化**: 共通の理解基盤でコミュニケーションコストを削減
+4. **バグの削減**: 適切な責務分離でバグの発生と影響を局所化
+
+目先の「簡単さ」に惑わされず、**長期的な価値**を見据えた設計判断をすることが、真のエンジニアリング力だと言えるでしょう。
+
+次回プロジェクトで「1ファイル修正で済む」という提案があった際には、ぜひこの記事の内容を思い出してください。そして、**本当にそれが「簡単」なのか**を検討してみてください。
+
+きっと、より良い設計の選択ができるはずです。
+
+## 参考リンク
+
+- [Rails Guides - アプリケーションを設定する](https://railsguides.jp/configuring.html)
+- [Rails Guides - レイアウトとレンダリング](https://railsguides.jp/layouts_and_rendering.html)
+- [Rails API Documentation](https://api.rubyonrails.org/)
+- [Martin Fowler - Separation of Concerns](https://martinfowler.com/articles/microservices.html)


### PR DESCRIPTION
## Summary
- _posts/配下にあった2つの記事をposts/配下に移行しました
- 既存フォーマットに合わせて変換（Jekyll形式 → 独自形式）
- 記事ID 43, 44 を新規採番

## 移行した記事
- 0043_rails-partial-basics.md: Rails初心者向けパーシャル解説記事
- 0044_rails-architecture-design-principles.md: Railsアーキテクチャ設計原則記事

## Test plan
- [ ] ビルドが正常に実行される
- [ ] デプロイが正常に実行される
- [ ] 記事が正しく表示される

🤖 Generated with [Claude Code](https://claude.ai/code)