### PR TITLE
コード例を汎用的で理解しやすいものに変更

### DIFF
--- a/posts/0043_rails-partial-basics.md
+++ b/posts/0043_rails-partial-basics.md
@@ -3,7 +3,7 @@ id: 43
 title: "Rails初心者が混乱しがちなパーシャル（部分テンプレート）の命名ルールと使い方"
 tags: ["Rails", "View", "Template", "Partial", "HAML"]
 create: "2025-09-05 00:28"
-update: "2025-09-05 03:21"
+update: "2025-09-05 03:44"
 ---
 
 # Rails初心者が混乱しがちなパーシャル（部分テンプレート）の命名ルールと使い方
@@ -32,11 +32,11 @@ Railsでビューを作成していると必ず出会うのが「パーシャル
 パーシャルファイルは**必ずアンダースコア（`_`）から始める**必要があります。
 
 ```
-app/views/users/
+app/views/posts/
 ├── index.html.erb          # 通常のビューファイル
 ├── show.html.erb           # 通常のビューファイル
-├── _profile.html.erb       # パーシャルファイル
-└── _navigation.html.erb    # パーシャルファイル
+├── _card.html.erb          # パーシャルファイル
+└── _header.html.erb        # パーシャルファイル
 ```
 
 ### 2. パーシャルの呼び出し
@@ -44,13 +44,13 @@ app/views/users/
 パーシャルを呼び出す際は、**アンダースコアを外して**`render`メソッドを使います。
 
 ```erb
-<!-- app/views/users/index.html.erb -->
-<h1>ユーザー一覧</h1>
-<%= render 'navigation' %>  <!-- _navigation.html.erb を呼び出し -->
+<!-- app/views/posts/index.html.erb -->
+<h1>記事一覧</h1>
+<%= render 'header' %>  <!-- _header.html.erb を呼び出し -->
 
-<div class="users-list">
-  <% @users.each do |user| %>
-    <%= render 'profile', user: user %>  <!-- _profile.html.erb を呼び出し -->
+<div class="posts-list">
+  <% @posts.each do |post| %>
+    <%= render 'card', post: post %>  <!-- _card.html.erb を呼び出し -->
   <% end %>
 </div>
 ```
@@ -61,18 +61,19 @@ app/views/users/
 
 ```erb
 <!-- 方法1: localsオプションを使用 -->
-<%= render 'profile', locals: { user: @user, show_email: true } %>
+<%= render 'card', locals: { post: @post, show_author: true } %>
 
 <!-- 方法2: 直接指定（推奨） -->
-<%= render 'profile', user: @user, show_email: true %>
+<%= render 'card', post: @post, show_author: true %>
 ```
 
 ```erb
-<!-- _profile.html.erb -->
-<div class="user-profile">
-  <h3><%= user.name %></h3>
-  <% if show_email %>
-    <p>Email: <%= user.email %></p>
+<!-- _card.html.erb -->
+<div class="post-card">
+  <h3><%= post.title %></h3>
+  <p><%= post.content %></p>
+  <% if show_author %>
+    <p>Author: <%= post.author.name %></p>
   <% end %>
 </div>
 ```
@@ -86,7 +87,7 @@ Railsでは**ファイルの種類を一目で判別**できるよう、以下�
 | ファイルの種類 | 命名例 | 用途 |
 |---|---|---|
 | **通常のビュー** | `index.html.erb` | 独立したページとして表示 |
-| **パーシャル** | `_profile.html.erb` | 部品として他から呼び出される |
+| **パーシャル** | `_card.html.erb` | 部品として他から呼び出される |
 | **レイアウト** | `application.html.erb` | ページ全体の枠組み |
 
 ### Convention over Configuration
@@ -104,26 +105,26 @@ Railsでは**ファイルの種類を一目で判別**できるよう、以下�
 
 ```erb
 <!-- 間違い -->
-<%= render '_profile' %>
-<%= render '_navigation' %>
-<%= render 'shared/_header' %>
+<%= render '_card' %>
+<%= render '_header' %>
+<%= render 'shared/_footer' %>
 ```
 
 ```erb
 <!-- 正しい -->
-<%= render 'profile' %>
-<%= render 'navigation' %>
-<%= render 'shared/header' %>
+<%= render 'card' %>
+<%= render 'header' %>
+<%= render 'shared/footer' %>
 ```
 
 ### ❌ 間違いパターン2: ファイル名にアンダースコアを付け忘れる
 
 ```
 <!-- 間違い -->
-app/views/users/profile.html.erb
+app/views/posts/card.html.erb
 
 <!-- 正しい -->
-app/views/users/_profile.html.erb
+app/views/posts/_card.html.erb
 ```
 
 ### エラーメッセージの読み方
@@ -131,12 +132,12 @@ app/views/users/_profile.html.erb
 アンダースコアを付け忘れたり、間違った呼び出しをすると以下のようなエラーが表示されます。
 
 ```
-ActionView::MissingTemplate: Missing partial users/_profile
+ActionView::MissingTemplate: Missing partial posts/_card
 ```
 
 このエラーメッセージのポイント：
 - **`Missing partial`**: パーシャルが見つからない
-- **`users/_profile`**: 探しているファイルは `app/views/users/_profile.html.erb`
+- **`posts/_card`**: 探しているファイルは `app/views/posts/_card.html.erb`
 - エラーメッセージには**アンダースコア付き**で表示されるが、renderでは**アンダースコアなし**で書く
 
 ## パーシャルファイルから他のパーシャルを呼び出す
@@ -144,11 +145,11 @@ ActionView::MissingTemplate: Missing partial users/_profile
 パーシャルファイル内でも、他のパーシャルを呼び出すことができます。
 
 ```erb
-<!-- _user_card.html.erb -->
-<div class="user-card">
-  <%= render 'user_avatar', user: user %>     <!-- _user_avatar.html.erb -->
-  <%= render 'user_details', user: user %>    <!-- _user_details.html.erb -->
-  <%= render 'user_actions', user: user %>    <!-- _user_actions.html.erb -->
+<!-- _article_card.html.erb -->
+<div class="article-card">
+  <%= render 'article_image', post: post %>     <!-- _article_image.html.erb -->
+  <%= render 'article_content', post: post %>   <!-- _article_content.html.erb -->
+  <%= render 'article_meta', post: post %>      <!-- _article_meta.html.erb -->
 </div>
 ```
 
@@ -166,9 +167,9 @@ app/views/
 │   ├── _header.html.erb
 │   ├── _footer.html.erb
 │   └── _sidebar.html.erb
-├── users/
+├── posts/
 │   ├── index.html.erb
-│   └── _profile.html.erb
+│   └── _card.html.erb
 └── admin/
     ├── index.html.erb
     └── _dashboard.html.erb
@@ -177,21 +178,21 @@ app/views/
 ### 呼び出し方法
 
 ```erb
-<!-- app/views/users/index.html.erb から -->
+<!-- app/views/posts/index.html.erb から -->
 <%= render 'shared/header' %>          <!-- app/views/shared/_header.html.erb -->
-<%= render 'profile', user: @user %>   <!-- app/views/users/_profile.html.erb -->
+<%= render 'card', post: @post %>      <!-- app/views/posts/_card.html.erb -->
 
 <!-- app/views/admin/index.html.erb から -->
 <%= render 'shared/header' %>          <!-- app/views/shared/_header.html.erb -->
-<%= render 'users/profile', user: @user %>  <!-- app/views/users/_profile.html.erb -->
+<%= render 'posts/card', post: @post %> <!-- app/views/posts/_card.html.erb -->
 ```
 
 ## パーシャルのファイル検索順序
 
 Railsは以下の順序でパーシャルファイルを検索します。
 
-1. **同じディレクトリ**: `app/views/users/_profile.html.erb`
-2. **共通ディレクトリ**: `app/views/application/_profile.html.erb`
+1. **同じディレクトリ**: `app/views/posts/_card.html.erb`
+2. **共通ディレクトリ**: `app/views/application/_card.html.erb`
 3. **その他のビューパス**
 
 この検索順序により、特定のコントローラー専用のパーシャルがある場合はそれを優先し、なければ共通のパーシャルを使用するという柔軟な運用が可能です。
@@ -205,7 +206,7 @@ Railsは以下の順序でパーシャルファイルを検索します。
 <nav class="main-navigation">
   <ul>
     <li><%= link_to 'ホーム', root_path %></li>
-    <li><%= link_to 'ユーザー', users_path %></li>
+    <li><%= link_to '記事', posts_path %></li>
     <li><%= link_to 'お問い合わせ', contact_path %></li>
   </ul>
 </nav>
@@ -233,16 +234,16 @@ Railsは以下の順序でパーシャルファイルを検索します。
 ### フォーム部品の再利用
 
 ```erb
-<!-- app/views/users/_form.html.erb -->
-<%= form_with model: user do |form| %>
+<!-- app/views/posts/_form.html.erb -->
+<%= form_with model: post do |form| %>
   <div class="form-group">
-    <%= form.label :name, '名前' %>
-    <%= form.text_field :name, class: 'form-control' %>
+    <%= form.label :title, 'タイトル' %>
+    <%= form.text_field :title, class: 'form-control' %>
   </div>
   
   <div class="form-group">
-    <%= form.label :email, 'メールアドレス' %>
-    <%= form.email_field :email, class: 'form-control' %>
+    <%= form.label :content, '内容' %>
+    <%= form.text_area :content, class: 'form-control' %>
   </div>
   
   <%= form.submit class: 'btn btn-primary' %>
@@ -250,13 +251,13 @@ Railsは以下の順序でパーシャルファイルを検索します。
 ```
 
 ```erb
-<!-- app/views/users/new.html.erb -->
-<h1>新規ユーザー登録</h1>
-<%= render 'form', user: @user %>
+<!-- app/views/posts/new.html.erb -->
+<h1>記事を書く</h1>
+<%= render 'form', post: @post %>
 
-<!-- app/views/users/edit.html.erb -->
-<h1>ユーザー情報編集</h1>
-<%= render 'form', user: @user %>
+<!-- app/views/posts/edit.html.erb -->
+<h1>記事を編集</h1>
+<%= render 'form', post: @post %>
 ```
 
 ## 覚え方のコツ
@@ -298,21 +299,22 @@ Railsが自動で補完してくれる部分：
 ERBの例をHAML記法で書くと以下のようになります。
 
 ```haml
--# app/views/users/index.html.haml
-%h1 ユーザー一覧
-= render 'navigation'
+-# app/views/posts/index.html.haml
+%h1 記事一覧
+= render 'header'
 
-.users-list
-  - @users.each do |user|
-    = render 'profile', user: user
+.posts-list
+  - @posts.each do |post|
+    = render 'card', post: post
 ```
 
 ```haml
--# app/views/users/_profile.html.haml
-.user-profile
-  %h3= user.name
-  - if show_email
-    %p= "Email: #{user.email}"
+-# app/views/posts/_card.html.haml
+.post-card
+  %h3= post.title
+  %p= post.content
+  - if show_author
+    %p= "Author: #{post.author.name}"
 ```
 
 ## まとめ

--- a/posts/0044_rails-architecture-design-principles.md
+++ b/posts/0044_rails-architecture-design-principles.md
@@ -3,7 +3,7 @@ id: 44
 title: "「1ファイルで済む」vs「正しい設計」- Railsアーキテクチャ原則が教える本当の価値"
 tags: ["Rails", "Architecture", "Design", "MVC", "Best Practices", "Refactoring"]
 create: "2025-09-05 01:58"
-update: "2025-09-05 03:21"
+update: "2025-09-05 03:44"
 ---
 
 # 「1ファイルで済む」vs「正しい設計」- Railsアーキテクチャ原則が教える本当の価値
@@ -25,10 +25,10 @@ update: "2025-09-05 03:21"
 
 ## 前提：実装すべき機能
 
-WEB版とスマートフォンアプリで**発送遅延通知を統一表示**する機能を実装する必要があります。
+WEB版とスマートフォンアプリで**メンテナンス通知を統一表示**する機能を実装する必要があります。
 
 ### 要件
-- **WEB側**: Railsビューで通知を表示
+- **WEB側**: Railsビューでメンテナンスバナーを表示
 - **APP側**: React Native経由でAPIから取得して表示
 - **表示条件**: 同じフラグで制御
 - **表示内容**: 同じテキストを使用
@@ -40,22 +40,22 @@ WEB版とスマートフォンアプリで**発送遅延通知を統一表示**�
 
 ### 実装方法
 ```ruby
-# app/controllers/api/app/v1/metadata_controller.rb（既存ファイル）
-class Api::App::V1::MetadataController < Api::App::V1::ApplicationController
+# app/controllers/api/v1/app_config_controller.rb（既存ファイル）
+class Api::V1::AppConfigController < Api::V1::BaseController
   def show
     render json: { 
-      minimumAppVersion: Device::MINIMUM_APP_VERSION,
-      showShippingNotice: true,  # ← 直接書く
-      shippingNoticeText: "現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。順次発送を進めております。お客様には大変なご不便とご心配をおかけし、申し訳ございません。"  # ← 直接書く
+      appVersion: "1.0.0",
+      showMaintenanceBanner: true,  # ← 直接書く
+      maintenanceBannerText: "システムメンテナンスのため、2月15日の深夜2時〜4時にサービスを停止いたします。"  # ← 直接書く
     }
   end
 end
 ```
 
 ```haml
-<!-- app/views/shared/_shipping_notice.html.haml（既存ファイル） -->
-.shipping-notice
-  現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。順次発送を進めております。お客様には大変なご不便とご心配をおかけし、申し訳ございません。
+<!-- app/views/shared/_maintenance_banner.html.haml（既存ファイル） -->
+.maintenance-banner
+  システムメンテナンスのため、2月15日の深夜2時〜4時にサービスを停止いたします。
 ```
 
 ### メリット
@@ -69,12 +69,12 @@ end
 #### 1. **同期の困難さ**
 ```ruby
 # APIコントローラー
-showShippingNotice: true,
-shippingNoticeText: "現在、多くの発送申請を..."
+showMaintenanceBanner: true,
+maintenanceBannerText: "システムメンテナンスのため..."
 
 # ビューファイル  
-.shipping-notice
-  現在、多くの発送申請を... <!-- 微妙に文言が違う！ -->
+.maintenance-banner
+  システムメンテナンスのため... <!-- 微妙に文言が違う！ -->
 ```
 
 #### 2. **変更時の手間**
@@ -110,23 +110,23 @@ Railsのアーキテクチャ原則に従い、以下を重視します：
 #### ステップ1: 通知設定の専用クラス作成
 
 ```ruby
-# app/lib/notification_config.rb（新規作成）
-class NotificationConfig
-  # 発送遅延通知
-  module ShippingDelay
+# app/lib/banner_config.rb（新規作成）
+class BannerConfig
+  # メンテナンス通知
+  module Maintenance
     ENABLED = true
-    TEXT = '現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。順次発送を進めております。お客様には大変なご不便とご心配をおかけし、申し訳ございません。'
+    TEXT = 'システムメンテナンスのため、2月15日の深夜2時〜4時にサービスを停止いたします。'
   end
 
   # 将来的な拡張用
-  module Maintenance
+  module Emergency
     ENABLED = false
-    TEXT = 'システムメンテナンスのため、一部機能がご利用いただけません。'
+    TEXT = '緊急メンテナンスのため、一時的にサービスを停止しています。'
   end
 
   module Campaign
     ENABLED = false
-    TEXT = '期間限定キャンペーン実施中！'
+    TEXT = '新機能リリース記念キャンペーン実施中！'
   end
 end
 ```
@@ -145,13 +145,13 @@ end
 #### ステップ2: APIコントローラーの修正
 
 ```ruby
-# app/controllers/api/app/v1/metadata_controller.rb
-class Api::App::V1::MetadataController < Api::App::V1::ApplicationController
+# app/controllers/api/v1/app_config_controller.rb
+class Api::V1::AppConfigController < Api::V1::BaseController
   def show
     render json: { 
-      minimumAppVersion: Device::MINIMUM_APP_VERSION,
-      showShippingNotice: NotificationConfig::ShippingDelay::ENABLED,
-      shippingNoticeText: NotificationConfig::ShippingDelay::TEXT
+      appVersion: "1.0.0",
+      showMaintenanceBanner: BannerConfig::Maintenance::ENABLED,
+      maintenanceBannerText: BannerConfig::Maintenance::TEXT
     }
   end
 end
@@ -172,52 +172,52 @@ end
 # app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
   # サイト全体で必要な場合はbefore_actionが有効
-  before_action :set_shipping_notification
+  before_action :set_maintenance_banner
   
   private
   
-  def set_shipping_notification
-    @shipping_notice_enabled = NotificationConfig::ShippingDelay::ENABLED
-    @shipping_notice_text = NotificationConfig::ShippingDelay::TEXT
+  def set_maintenance_banner
+    @maintenance_banner_enabled = BannerConfig::Maintenance::ENABLED
+    @maintenance_banner_text = BannerConfig::Maintenance::TEXT
   end
   
   # 特定のページでのみ使用する場合の代替方法
-  # helper_method :shipping_notice_enabled?, :shipping_notice_text
+  # helper_method :maintenance_banner_enabled?, :maintenance_banner_text
   
-  # def shipping_notice_enabled?
-  #   NotificationConfig::ShippingDelay::ENABLED
+  # def maintenance_banner_enabled?
+  #   BannerConfig::Maintenance::ENABLED
   # end
   
-  # def shipping_notice_text
-  #   NotificationConfig::ShippingDelay::TEXT
+  # def maintenance_banner_text
+  #   BannerConfig::Maintenance::TEXT
   # end
 end
 ```
 
 ```haml
-<!-- app/views/shared/_shipping_notice.html.haml -->
-- if @shipping_notice_enabled
-  .shipping-notice
-    = @shipping_notice_text
+<!-- app/views/shared/_maintenance_banner.html.haml -->
+- if @maintenance_banner_enabled
+  .maintenance-banner
+    = @maintenance_banner_text
 ```
 
 #### ステップ4: テストの更新
 
 ```ruby
-# spec/requests/api/app/v1/metadata_controller_spec.rb
-RSpec.describe Api::App::V1::MetadataController do
+# spec/requests/api/v1/app_config_controller_spec.rb
+RSpec.describe Api::V1::AppConfigController do
   describe 'GET #show' do
-    context '発送通知が有効な場合' do
+    context 'メンテナンスバナーが有効な場合' do
       before do
-        stub_const('NotificationConfig::ShippingDelay::ENABLED', true)
-        stub_const('NotificationConfig::ShippingDelay::TEXT', 'テスト用メッセージ')
+        stub_const('BannerConfig::Maintenance::ENABLED', true)
+        stub_const('BannerConfig::Maintenance::TEXT', 'テスト用メッセージ')
       end
 
       it '適切なレスポンスを返す' do
-        get api_app_v1_metadata_path
+        get api_v1_app_config_path
         json = JSON.parse(response.body)
-        expect(json['showShippingNotice']).to be_truthy
-        expect(json['shippingNoticeText']).to eq('テスト用メッセージ')
+        expect(json['showMaintenanceBanner']).to be_truthy
+        expect(json['maintenanceBannerText']).to eq('テスト用メッセージ')
       end
     end
   end
@@ -228,13 +228,13 @@ end
 
 ```
 新規作成: 1ファイル
-├── app/lib/notification_config.rb
+├── app/lib/banner_config.rb
 
 修正: 4ファイル  
-├── app/controllers/api/app/v1/metadata_controller.rb
+├── app/controllers/api/v1/app_config_controller.rb
 ├── app/controllers/application_controller.rb
-├── app/views/shared/_shipping_notice.html.haml
-└── spec/requests/api/app/v1/metadata_controller_spec.rb
+├── app/views/shared/_maintenance_banner.html.haml
+└── spec/requests/api/v1/app_config_controller_spec.rb
 
 合計: 5ファイル
 ```
@@ -282,7 +282,7 @@ end
 ```ruby
 # 各ファイルを個別に修正が必要
 # APIコントローラー
-showShippingNotice: false,  # ← 手動変更
+showMaintenanceBanner: false,  # ← 手動変更
 
 # ビューファイル
 - if false  # ← 手動変更（しかもこれだと見た目が悪い）
@@ -291,7 +291,7 @@ showShippingNotice: false,  # ← 手動変更
 **アーキテクチャ原則の場合**
 ```ruby
 # 1箇所変更するだけ
-module ShippingDelay
+module Maintenance
   ENABLED = false  # ← この1行だけ
   TEXT = '...'
 end
@@ -303,26 +303,26 @@ end
 ```ruby
 # 各ファイルにバラバラに追加
 # APIコントローラー
-showMaintenanceNotice: true,
-maintenanceNoticeText: "...",
+showEmergencyBanner: true,
+emergencyBannerText: "...",
 
 # ビューファイル（別ファイルに）
 - if true
-  .maintenance-notice
-    メンテナンス中...
+  .emergency-banner
+    緒急メンテナンス中...
 ```
 
 **アーキテクチャ原則の場合**
 ```ruby
 # 設定クラスに追加するだけ
-module Maintenance
+module Emergency
   ENABLED = true
-  TEXT = 'メンテナンス中...'
+  TEXT = '緒急メンテナンス中...'
 end
 
 # 使用箇所では統一的に参照
-NotificationConfig::Maintenance::ENABLED
-NotificationConfig::Maintenance::TEXT
+BannerConfig::Emergency::ENABLED
+BannerConfig::Emergency::TEXT
 ```
 
 ### 長期的なコスト分析
@@ -363,26 +363,26 @@ ON/OFF切替（月1回）: 0.1時間 × 6ヶ月 = 0.6時間
 ```ruby
 # ❌ 情報が分散
 # APIコントローラー
-shippingNoticeText: "現在、多くの発送申請を..."
+maintenanceBannerText: "システムメンテナンスのため..."
 
 # ビューファイル  
-.notice 現在、多くの発送申請を...
+.banner システムメンテナンスのため...
 
 # 設定ファイル
-SHIPPING_NOTICE = "現在、多くの発送申請を..."
+MAINTENANCE_BANNER = "システムメンテナンスのため..."
 ```
 
 **解決**: 情報源を1箇所に集約
 ```ruby
 # ✅ 単一情報源
-class NotificationConfig
-  module ShippingDelay
-    TEXT = '現在、多くの発送申請を...'  # ← ここだけ
+class BannerConfig
+  module Maintenance
+    TEXT = 'システムメンテナンスのため...'  # ← ここだけ
   end
 end
 
 # どこからでもこの値を参照
-NotificationConfig::ShippingDelay::TEXT
+BannerConfig::Maintenance::TEXT
 ```
 
 ### 2. Separation of Concerns（関心の分離）
@@ -391,7 +391,7 @@ NotificationConfig::ShippingDelay::TEXT
 
 | コンポーネント | 責務 | 担当しないこと |
 |---|---|---|
-| **NotificationConfig** | 通知設定の管理 | HTTP処理、DB操作 |
+| **BannerConfig** | バナー設定の管理 | HTTP処理、DB操作 |
 | **Controller** | リクエスト処理、データ準備 | 設定値の決定、ビューロジック |
 | **View** | 表示 | データ取得、ビジネスロジック |
 


### PR DESCRIPTION
## Summary
- 記事のコード例を実際の開発コードから汎用的で理解しやすい例に変更しました
- より初心者エンジニアにとってわかりやすいドメイン例を採用

## 変更内容

### Rails パーシャル記事
- ユーザー関連の例 → ブログ記事関連の例に変更
- `user/profile` → `posts/card` でより汎用的に

### Rails アーキテクチャ記事  
- 発送遅延通知 → メンテナンス通知バナーに変更
- 実際のプロジェクト固有コードから学習用の例に変更

## Test plan
- [ ] ビルドが正常に実行される
- [ ] デプロイが正常に実行される  
- [ ] 記事が正しく表示される
- [ ] コード例がわかりやすく表示される

🤖 Generated with [Claude Code](https://claude.ai/code)