### PR TITLE
タイムスタンプ形式ファイルをposts/から_posts/に移動

### DIFF
--- a/_posts/2025-09-05-react-component-conditional-rendering-best-practices.md
+++ b/_posts/2025-09-05-react-component-conditional-rendering-best-practices.md
@@ -1,0 +1,429 @@
+---
+id: 100
+title: "React コンポーネントの条件分岐レンダリング：判定ロジックはどこに配置するべきか"
+tags: ["React", "TypeScript", "条件分岐", "アーキテクチャ", "ベストプラクティス"]
+create: "2025-09-05 13:19"
+update: "2025-09-05 13:19"
+---
+
+# React コンポーネントの条件分岐レンダリング：判定ロジックはどこに配置するべきか
+
+## はじめに
+
+React開発において、コンポーネントの表示/非表示を制御する際に「判定ロジックをどこに配置するべきか」は重要な設計判断です。特に、API から取得したデータに基づく条件分岐では、親コンポーネントで判定するか、子コンポーネント内で判定するかで保守性や再利用性が大きく変わります。
+
+本記事では、実際のReact Nativeアプリでの発送遅延通知機能を例に、条件分岐の配置について詳しく解説します。
+
+## 具体的な事例：発送遅延通知コンポーネント
+
+### 要件
+- APIから取得したメタデータに基づいて発送遅延通知を表示
+- フラグが `true` かつ テキストが存在する場合のみ表示
+- 複数画面で再利用される可能性
+
+### 実装パターン1：親コンポーネントで判定
+
+```tsx
+// 親コンポーネント（呼び出し元）
+const OriginalPackProductsPage = () => {
+  const { metadata } = useAppMetadata();
+  
+  // 親で表示条件を判定
+  const shouldShowNotice = metadata?.isShowShippingDelayNotice && 
+                          metadata?.shippingDelayNoticeText;
+
+  return (
+    <View>
+      {/* 親で条件を判定してから子を呼び出す */}
+      {shouldShowNotice && (
+        <ShippingDelayNotice text={metadata.shippingDelayNoticeText} />
+      )}
+    </View>
+  );
+};
+
+// 子コンポーネント（表示専用）
+const ShippingDelayNotice = ({ text }: { text: string }) => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{text}</Text>
+    </View>
+  );
+};
+```
+
+### 実装パターン2：子コンポーネントで判定（推奨）
+
+```tsx
+// 親コンポーネント（呼び出し元）
+const OriginalPackProductsPage = () => {
+  return (
+    <View>
+      {/* シンプルに子コンポーネントを呼び出すだけ */}
+      <ShippingDelayNotice />
+    </View>
+  );
+};
+
+// 子コンポーネント（判定＋表示）
+const ShippingDelayNotice = () => {
+  const { metadata } = useAppMetadata();
+  
+  const isShowNotice = metadata?.isShowShippingDelayNotice && 
+                      metadata?.shippingDelayNoticeText;
+
+  // 発送遅延通知フラグがfalseまたはテキストを取得できていない場合は何も表示しない
+  if (!isShowNotice) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>
+        {metadata.shippingDelayNoticeText}
+      </Text>
+    </View>
+  );
+};
+```
+
+## 各パターンの比較分析
+
+### パターン1（親で判定）の特徴
+
+**メリット：**
+- 子コンポーネントがシンプル
+- propsが明確で単体テストしやすい
+- 表示ロジックと描画ロジックが分離されている
+
+**デメリット：**
+- 呼び出し元が毎回同じ条件判定を書く必要がある
+- APIの構造変更時に複数箇所の修正が必要
+- 再利用時に条件判定のコードが重複する
+
+### パターン2（子で判定）の特徴
+
+**メリット：**
+- 呼び出し元がシンプル
+- 条件判定ロジックが1箇所に集約
+- 再利用時の実装が簡単
+- APIの構造変更時の影響範囲が限定的
+
+**デメリット：**
+- 子コンポーネントがAPI依存になる
+- 単体テスト時にAPIモックが必要
+
+## 設計原則から見た判断基準
+
+### 1. 単一責任の原則（Single Responsibility Principle）
+
+```tsx
+// ❌ 親が複数の責任を持つ
+const Parent = () => {
+  // 1. データ取得の責任
+  const { metadata } = useAppMetadata();
+  
+  // 2. 表示判定の責任
+  const shouldShow = metadata?.flag && metadata?.text;
+  
+  // 3. UI構築の責任
+  return <View>{shouldShow && <Child />}</View>;
+};
+
+// ✅ 責任を適切に分離
+const Parent = () => {
+  // UI構築の責任のみ
+  return <View><Child /></View>;
+};
+
+const Child = () => {
+  // データ取得と表示判定の責任
+  const { metadata } = useAppMetadata();
+  const shouldShow = metadata?.flag && metadata?.text;
+  if (!shouldShow) return null;
+  
+  return <View>...</View>;
+};
+```
+
+### 2. DRY原則（Don't Repeat Yourself）
+
+```tsx
+// ❌ 複数箇所で同じ判定ロジック
+const PageA = () => {
+  const { metadata } = useAppMetadata();
+  const shouldShow = metadata?.isShowShippingDelayNotice && 
+                    metadata?.shippingDelayNoticeText;
+  return shouldShow && <ShippingDelayNotice />;
+};
+
+const PageB = () => {
+  const { metadata } = useAppMetadata();
+  // 同じ判定ロジックが重複
+  const shouldShow = metadata?.isShowShippingDelayNotice && 
+                    metadata?.shippingDelayNoticeText;
+  return shouldShow && <ShippingDelayNotice />;
+};
+
+// ✅ 判定ロジックを1箇所に集約
+const PageA = () => <ShippingDelayNotice />;
+const PageB = () => <ShippingDelayNotice />;
+
+const ShippingDelayNotice = () => {
+  // 判定ロジックが1箇所のみ
+  const { metadata } = useAppMetadata();
+  const shouldShow = metadata?.isShowShippingDelayNotice && 
+                    metadata?.shippingDelayNoticeText;
+  if (!shouldShow) return null;
+  return <View>...</View>;
+};
+```
+
+### 3. 関心の分離（Separation of Concerns）
+
+コンポーネントの責任を明確に分離することで、保守性が向上します：
+
+```tsx
+// ✅ 各コンポーネントが明確な責任を持つ
+const ShippingDelayNotice = () => {
+  // 発送遅延通知に関する全ての責任を集約
+  const { metadata } = useAppMetadata();
+  
+  // この条件は「発送遅延通知」の表示条件なので、
+  // このコンポーネントが知っているべき知識
+  const isShowNotice = metadata?.isShowShippingDelayNotice && 
+                      metadata?.shippingDelayNoticeText;
+
+  if (!isShowNotice) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>
+        {metadata.shippingDelayNoticeText}
+      </Text>
+    </View>
+  );
+};
+```
+
+## 実践的な判断基準
+
+### 子コンポーネントで判定すべき場合
+
+1. **コンポーネント固有の表示条件**
+   ```tsx
+   // ユーザープロフィール画像の表示判定
+   const Avatar = () => {
+     const { user } = useAuth();
+     // アバターコンポーネント自身が判断すべき条件
+     if (!user?.avatarUrl) return <DefaultAvatar />;
+     return <img src={user.avatarUrl} />;
+   };
+   ```
+
+2. **複数箇所で再利用される条件**
+   ```tsx
+   // 通知バッジの表示判定
+   const NotificationBadge = () => {
+     const { unreadCount } = useNotification();
+     // バッジ表示の条件はバッジコンポーネント自身が持つべき
+     if (unreadCount === 0) return null;
+     return <Badge count={unreadCount} />;
+   };
+   ```
+
+3. **APIデータ構造に密結合な条件**
+
+### 親コンポーネントで判定すべき場合
+
+1. **ビジネスロジックに関わる条件**
+   ```tsx
+   const OrderPage = () => {
+     const { order } = useOrder();
+     // 注文状態は親のビジネスロジック
+     const canShowShippingInfo = order.status === 'shipped';
+     
+     return (
+       <div>
+         {canShowShippingInfo && <ShippingInfo orderId={order.id} />}
+       </div>
+     );
+   };
+   ```
+
+2. **画面固有の表示制御**
+   ```tsx
+   const Dashboard = () => {
+     const [activeTab, setActiveTab] = useState('overview');
+     // タブ表示は画面固有のUI制御
+     return (
+       <div>
+         {activeTab === 'analytics' && <AnalyticsChart />}
+       </div>
+     );
+   };
+   ```
+
+## TypeScriptでの型安全な実装
+
+条件分岐を子コンポーネントで行う場合の型安全な実装例：
+
+```tsx
+// APIレスポンスの型定義
+type AppMetadata = {
+  minimumAppVersion: string;
+  isShowShippingDelayNotice: boolean;
+  shippingDelayNoticeText: string;
+};
+
+// オプショナルチェーニングを活用した安全な条件判定
+const ShippingDelayNotice = () => {
+  const { metadata } = useAppMetadata();
+  
+  // TypeScriptの型システムと組み合わせた安全な判定
+  const isShowNotice = metadata?.isShowShippingDelayNotice && 
+                      metadata?.shippingDelayNoticeText;
+
+  // 発送遅延通知フラグがfalseまたはテキストを取得できていない場合は何も表示しない
+  if (!isShowNotice) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>
+        {/* この時点でmetadata.shippingDelayNoticeTextは存在することが保証されている */}
+        {metadata.shippingDelayNoticeText}
+      </Text>
+    </View>
+  );
+};
+```
+
+## オプショナルチェーニング（?.）の重要性
+
+APIから取得したデータの条件判定では、オプショナルチェーニングが重要な役割を果たします：
+
+```tsx
+// ❌ unsafe - metadataがnullの場合エラー
+if (metadata.isShowShippingDelayNotice && metadata.shippingDelayNoticeText) {
+  // TypeError: Cannot read property 'isShowShippingDelayNotice' of null
+}
+
+// ✅ safe - metadataがnull/undefinedでも安全
+if (metadata?.isShowShippingDelayNotice && metadata?.shippingDelayNoticeText) {
+  // metadataがnullの場合、undefinedが返される
+}
+```
+
+**解説：**
+- `metadata?.isShowShippingDelayNotice` は metadata が null/undefined の場合に undefined を返す
+- `&&` 演算子により、左辺が falsy な場合は右辺を評価しない
+- この組み合わせで安全な条件判定が実現できる
+
+## テスト観点での考慮事項
+
+### 子コンポーネントで判定する場合のテスト
+
+```tsx
+// APIモックを使った統合テスト
+describe('ShippingDelayNotice', () => {
+  it('フラグがtrueでテキストがある場合に表示される', async () => {
+    // APIレスポンスをモック
+    const mockMetadata = {
+      isShowShippingDelayNotice: true,
+      shippingDelayNoticeText: '発送が遅延しています'
+    };
+    
+    jest.mocked(useAppMetadata).mockReturnValue({
+      metadata: mockMetadata,
+      isLoading: false,
+      error: null
+    });
+
+    const { getByText } = render(<ShippingDelayNotice />);
+    expect(getByText('発送が遅延しています')).toBeInTheDocument();
+  });
+
+  it('フラグがfalseの場合は表示されない', () => {
+    const mockMetadata = {
+      isShowShippingDelayNotice: false,
+      shippingDelayNoticeText: '発送が遅延しています'
+    };
+    
+    jest.mocked(useAppMetadata).mockReturnValue({
+      metadata: mockMetadata,
+      isLoading: false,
+      error: null
+    });
+
+    const { container } = render(<ShippingDelayNotice />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('テキストが空文字の場合は表示されない', () => {
+    const mockMetadata = {
+      isShowShippingDelayNotice: true,
+      shippingDelayNoticeText: ''
+    };
+    
+    jest.mocked(useAppMetadata).mockReturnValue({
+      metadata: mockMetadata,
+      isLoading: false,
+      error: null
+    });
+
+    const { container } = render(<ShippingDelayNotice />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+## 実際の開発での判断フロー
+
+条件分岐の配置を決める際の判断フローチャート：
+
+```
+1. この条件はコンポーネント固有のものか？
+   YES → 子コンポーネントで判定
+   NO → 次へ
+
+2. 複数箇所で同じ条件を使用するか？
+   YES → 子コンポーネントで判定
+   NO → 次へ
+
+3. 画面やビジネスロジック固有の条件か？
+   YES → 親コンポーネントで判定
+   NO → プロジェクト方針に従う
+```
+
+## 結論
+
+**推奨：子コンポーネント内での条件判定**
+
+今回の発送遅延通知のような場合、以下の理由から子コンポーネント内での判定が適している：
+
+1. **保守性**: 条件変更時の影響範囲が限定的
+2. **再利用性**: 他画面での利用時に実装が簡単
+3. **責任の明確化**: コンポーネント自身が表示条件を管理
+4. **DRY原則**: 条件判定ロジックの重複を防止
+
+ただし、画面固有のビジネスロジックや複雑な状態管理が絡む場合は、親コンポーネントでの判定も有効です。重要なのは、プロジェクトのアーキテクチャと要件に応じて一貫した方針を採用することです。
+
+## まとめのポイント
+
+- **コンポーネント固有の条件**は子コンポーネントで判定する
+- **DRY原則**を重視して重複コードを避ける
+- **TypeScript**とオプショナルチェーニングで型安全性を確保
+- **テストしやすさ**も考慮してアーキテクチャを決定する
+- **一貫性**のある方針をプロジェクト全体で採用する
+
+適切な条件分岐の配置により、保守性が高く拡張しやすいReactアプリケーションを構築できます。
+
+## 参考記事
+
+- [React 公式ドキュメント - 条件付きレンダー](https://react.dev/learn/conditional-rendering)
+- [React Design Patterns and Best Practices](https://www.patterns.dev/posts/react-design-patterns)
+- [TypeScript 公式ドキュメント - Optional Chaining](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#optional-properties)

--- a/_posts/2025-09-05-ruby-freeze-method-explained.md
+++ b/_posts/2025-09-05-ruby-freeze-method-explained.md
@@ -1,0 +1,245 @@
+---
+layout: post
+title: "Ruby の .freeze メソッドを理解する：オブジェクトの不変性とメモリ効率"
+date: "2025-09-05 13:22"
+create: "2025-09-05 13:22"
+update: "2025-09-05 13:22"
+tags: ["Ruby", "Rails", "プログラミング", "メモリ管理", "定数"]
+categories: ["Ruby", "プログラミング"]
+description: "Ruby の .freeze メソッドの役割と使い方を初心者向けに解説。オブジェクトの不変性、定数での活用、メモリ効率化について具体例とともに説明します。"
+---
+
+Rubyのコードを読んでいると、文字列の末尾に`.freeze`が付いているのを見かけることがありませんか？この記事では、`.freeze`メソッドの役割や使い方について、初心者の方にも分かりやすく解説します。
+
+## .freeze メソッドとは
+
+`.freeze`は、Rubyのオブジェクトを**不変（immutable）**にするメソッドです。一度`.freeze`を適用したオブジェクトは、その内容を変更することができなくなります。
+
+```ruby
+# 通常の文字列（変更可能）
+message = "Hello"
+puts message  # => "Hello"
+
+message << " World"  # 文字列に追加
+puts message  # => "Hello World"
+
+# freeze された文字列（変更不可能）
+frozen_message = "Hello".freeze
+puts frozen_message  # => "Hello"
+
+frozen_message << " World"  # エラーが発生！
+# FrozenError: can't modify frozen String
+```
+
+## なぜ .freeze を使うのか
+
+### 1. 安全性の向上
+
+定数や重要なデータを意図しない変更から守ることができます。
+
+```ruby
+# 危険な例：定数が変更される可能性
+API_BASE_URL = "https://api.example.com"
+API_BASE_URL << "/v2"  # 定数が変更されてしまう！
+
+# 安全な例：freeze で保護
+API_BASE_URL = "https://api.example.com".freeze
+API_BASE_URL << "/v2"  # エラー：変更できない
+```
+
+### 2. メモリ効率の向上
+
+Rubyは同じ内容のfrozenオブジェクトを再利用するため、メモリ使用量を削減できます。
+
+```ruby
+# freeze なし：毎回新しいオブジェクトが作られる
+def get_status_pending
+  "pending"  # 毎回新しい文字列オブジェクト
+end
+
+# freeze あり：同じオブジェクトが再利用される
+def get_status_pending
+  "pending".freeze  # 同一のfrozenオブジェクトが再利用
+end
+```
+
+### 3. RuboCopの推奨事項
+
+RuboCopの`Style/MutableConstant`ルールにより、定数には`.freeze`の使用が推奨されています。
+
+## 実践的な使用例
+
+### Rails の設定ファイルでの使用
+
+```ruby
+class ApplicationConfig
+  # エラーメッセージ定数
+  ERROR_MESSAGES = {
+    not_found: "指定されたリソースが見つかりません".freeze,
+    unauthorized: "認証が必要です".freeze,
+    server_error: "サーバーエラーが発生しました".freeze
+  }.freeze
+  
+  # APIエンドポイント
+  API_ENDPOINTS = [
+    "/api/v1/users".freeze,
+    "/api/v1/products".freeze,
+    "/api/v1/orders".freeze
+  ].freeze
+end
+```
+
+### 設定値の保護
+
+```ruby
+class NotificationConfig
+  module ShippingDelay
+    ENABLED = false
+    TEXT = "現在、多くの発送申請をいただいており、お届けまでにお時間を要しております。".freeze
+  end
+end
+```
+
+## 配列やハッシュでの .freeze
+
+文字列以外のオブジェクトでも`.freeze`は使用できます。
+
+### 配列の場合
+
+```ruby
+# 配列をfreeze
+colors = ["red", "green", "blue"].freeze
+colors << "yellow"  # エラー：配列に要素を追加できない
+
+# ただし、配列の要素自体はfreezeされない
+colors[0] << "dish"  # "reddish" になる（要素の変更は可能）
+
+# 配列と要素の両方をfreezeする場合
+colors = ["red".freeze, "green".freeze, "blue".freeze].freeze
+```
+
+### ハッシュの場合
+
+```ruby
+# ハッシュをfreeze
+config = { host: "localhost", port: 3000 }.freeze
+config[:database] = "myapp"  # エラー：新しいキーを追加できない
+config[:host] = "example.com"  # エラー：既存の値を変更できない
+```
+
+## freeze の確認方法
+
+オブジェクトがfreezeされているかどうかは`frozen?`メソッドで確認できます。
+
+```ruby
+text = "Hello"
+puts text.frozen?  # => false
+
+text.freeze
+puts text.frozen?  # => true
+```
+
+## パフォーマンスへの影響
+
+### メモリ使用量の比較
+
+```ruby
+# freeze なし：毎回新しいオブジェクトが作成される
+1000.times do
+  status = "active"  # 1000個の異なるオブジェクト
+end
+
+# freeze あり：同じオブジェクトが再利用される
+1000.times do
+  status = "active".freeze  # 1個のfrozenオブジェクトが再利用
+end
+```
+
+### ベンチマーク例
+
+実際のパフォーマンスを計測してみましょう。
+
+```ruby
+require 'benchmark'
+
+# 10万回の文字列生成でのベンチマーク
+n = 100_000
+
+Benchmark.bm(15) do |x|
+  x.report("freeze なし:") do
+    n.times { "Hello World" }
+  end
+  
+  x.report("freeze あり:") do
+    n.times { "Hello World".freeze }
+  end
+end
+
+# 結果例：
+#                      user     system      total        real
+# freeze なし:      0.020000   0.000000   0.020000 (  0.023341)
+# freeze あり:      0.010000   0.000000   0.010000 (  0.012156)
+```
+
+## 注意点とベストプラクティス
+
+### 1. 深いfreezeはされない
+
+```ruby
+data = { users: ["alice", "bob"] }.freeze
+data[:users] << "charlie"  # 成功：配列自体はfreezeされていない
+
+# 完全にfreezeする場合は各要素も個別にfreezeが必要
+data = { 
+  users: ["alice".freeze, "bob".freeze].freeze 
+}.freeze
+```
+
+### 2. 定数には積極的に使用
+
+```ruby
+class UserStatus
+  ACTIVE = "active".freeze
+  INACTIVE = "inactive".freeze
+  PENDING = "pending".freeze
+  
+  ALL_STATUSES = [ACTIVE, INACTIVE, PENDING].freeze
+end
+```
+
+### 3. 動的な値には使用しない
+
+```ruby
+# 良い例：固定値
+DEFAULT_MESSAGE = "Welcome to our service".freeze
+
+# 悪い例：動的な値
+current_time = Time.now.to_s.freeze  # 意味がない
+```
+
+## まとめ
+
+`.freeze`メソッドは、Rubyにおいてオブジェクトの安全性とパフォーマンスを向上させる重要な機能です。
+
+**主な利点：**
+- オブジェクトの意図しない変更を防止
+- メモリ使用量の削減
+- 同一オブジェクトの再利用によるパフォーマンス向上
+
+**使用すべき場面：**
+- 定数の定義
+- 設定値やエラーメッセージ
+- 固定的なデータ構造
+
+**注意点：**
+- 深いfreezeは自動的に行われない
+- 動的な値には適用しない
+- freezeされたオブジェクトは変更不可能
+
+`.freeze`を適切に使用することで、より安全で効率的なRubyコードを書くことができます。定数を定義する際は、ぜひ`.freeze`の使用を検討してみてください。
+
+## 参考リンク
+
+- [Ruby公式ドキュメント - Object#freeze](https://docs.ruby-lang.org/ja/latest/method/Object/i/freeze.html)
+- [RuboCop Style/MutableConstant](https://docs.rubocop.org/rubocop/cops_style.html#stylemutableconstant)
+- [Ruby公式ドキュメント - Object#frozen?](https://docs.ruby-lang.org/ja/latest/method/Object/i/frozen=3f.html)

--- a/_posts/2025-09-06-understanding-jwt-and-jwt-signature.md
+++ b/_posts/2025-09-06-understanding-jwt-and-jwt-signature.md
@@ -1,0 +1,358 @@
+---
+title: "JWT（JSON Web Token）とJWT Signatureを分かりやすく解説"
+date: 2025-09-06 10:13
+categories: [Web開発, セキュリティ, 認証]
+tags: [JWT, 認証, Firebase, セキュリティ, トークン]
+description: "JWTの基本概念から署名の仕組み、Firebase tokenでの実例まで、初心者にも分かりやすく詳しく解説します。"
+---
+
+## はじめに
+
+Web開発において「JWT」という言葉をよく耳にしますが、その仕組みを正確に理解していますか？特に「Signature has expired」といったエラーに遭遇した時、なぜこのエラーが発生するのか理解できていると、適切な対処ができるようになります。
+
+本記事では、JWTの基本概念から、その中核を成すSignature（署名）の仕組みまで、初心者にも分かりやすく解説します。
+
+## JWTとは何か
+
+**JWT（JSON Web Token）**は、当事者間で安全に情報を伝送するためのオープンスタンダードです。主にWebアプリケーションの認証・認可に使用されます。
+
+### JWTが生まれた背景
+
+従来のセッション認証では、サーバー側でセッション情報を保持する必要がありました。しかし、マイクロサービスアーキテクチャやSPA（Single Page Application）の普及により、**ステートレス**（状態を持たない）な認証方式が求められるようになりました。
+
+```
+従来のセッション認証の課題:
+- サーバー側でセッション情報を保持する必要
+- 複数のサーバー間でのセッション共有が困難
+- スケーラビリティの問題
+```
+
+JWTは、これらの課題を解決する認証方式として登場しました。
+
+## JWTの構造
+
+JWTは3つの部分がドット（.）で区切られた文字列です：
+
+```
+Header.Payload.Signature
+```
+
+### 実際のJWTの例
+
+```
+eyJhbGciOiJSUzI1NiIsImtpZCI6IjE2NzAyODA2MDc2In0.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vcG9rZWNhLWFwcCIsImF1ZCI6InBva2VjYS1hcHAiLCJhdXRoX3RpbWUiOjE3MjU1ODk5ODQsInVzZXJfaWQiOiJhYmMxMjMiLCJzdWIiOiJhYmMxMjMiLCJpYXQiOjE3MjU1ODk5ODQsImV4cCI6MTcyNTU5MzU4NCwiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImZpcmViYXNlIjp7ImlkZW50aXRpZXMiOnsiZW1haWwiOlsidXNlckBleGFtcGxlLmNvbSJdfSwic2lnbl9pbl9wcm92aWRlciI6InBhc3N3b3JkIn19.K1fVX2pQk3...（Signature部分は省略）
+```
+
+一見複雑に見えますが、各部分を分解してみましょう。
+
+**重要**: HeaderとPayloadは、JSON形式のデータを**Base64URLエンコード**という方法で安全な文字列に変換してから結合されています。
+
+### 1. Header（ヘッダー）
+
+```json
+{
+  "alg": "RS256",
+  "kid": "1670280607656"
+}
+```
+
+**Headerの役割:**
+- `alg`: 署名に使用するアルゴリズム
+- `kid`: 署名に使用する鍵のID（複数の公開鍵を管理している場合に、どの鍵で検証すればよいかを特定するための識別子）
+
+### 2. Payload（ペイロード）
+
+```json
+{
+  "iss": "https://securetoken.google.com/pokeca-app",
+  "aud": "pokeca-app",
+  "auth_time": 1725589984,
+  "user_id": "abc123",
+  "sub": "abc123",
+  "iat": 1725589984,
+  "exp": 1725593584,
+  "email": "user@example.com",
+  "email_verified": true,
+  "firebase": {
+    "identities": {
+      "email": ["user@example.com"]
+    },
+    "sign_in_provider": "password"
+  }
+}
+```
+
+**重要なフィールド:**
+- `iss`: 発行者（Issuer）
+- `aud`: 対象者（Audience）
+- `exp`: 有効期限（Expiration）← **これが今回の記事の重要ポイント**
+- `iat`: 発行時刻（Issued At）
+- `user_id`: ユーザーID
+- `sub`: 標準クレーム「Subject」（そのトークンが誰に関するものかを示す。Firebaseでは慣例的に`user_id`と同じ値）
+
+### 3. Signature（署名）
+
+```
+K1fVX2pQk3...（実際の署名データ）
+```
+
+**Signatureの生成方法（例: RS256の場合）:**
+```
+RSASHA256(
+  base64UrlEncode(header) + "." +
+  base64UrlEncode(payload),
+  privateKey
+)
+```
+
+署名は、エンコードされたHeaderとPayload、そして**秘密鍵（Private Key）**を使って生成されます。この署名は、対になる**公開鍵（Public Key）**でのみ検証できます。これにより、秘密鍵を持つ発行者だけが有効なJWTを生成できることが保証されます。
+
+## JWT Signatureの詳細解説
+
+### Signatureとは
+
+**Signature（署名）**は、JWTの真正性と完全性を保証するための暗号学的な仕組みです。
+
+### Signatureの2つの重要な役割
+
+#### 1. 改ざん検知（完全性の保証）
+```
+元のトークン: Header.Payload.ValidSignature
+改ざん後:     Header.ModifiedPayload.ValidSignature
+                    ↑                    ↑
+              内容が変更された      署名は元のまま
+```
+
+署名を検証することで、トークンが改ざんされていないことを確認できます。
+
+#### 2. 発行者の認証
+JWTは特定の秘密鍵（または秘密の文字列）で署名されます。その署名を対応する公開鍵（または同じ文字列）で検証することで、トークンが信頼できる発行者によって作成されたことを確認できます。
+
+### 署名アルゴリズム: HS256とRS256の違い
+
+JWTの署名でよく使われるアルゴリズムにHS256とRS256があります。
+
+#### HS256 (HMAC using SHA-256)
+- **方式**: 対称鍵暗号（共通鍵暗号）
+- **仕組み**: 署名の生成と検証に、同じ一つの「秘密鍵（secret）」を使用
+- **ユースケース**: サーバー内でのみJWTを完結させる場合など、署名と検証を行う主体が同じ場合に適している
+
+#### RS256 (RSA Signature with SHA-256)
+- **方式**: 非対称鍵暗号（公開鍵暗号）
+- **仕組み**: 署名の生成には「秘密鍵」、検証には「公開鍵」のペアを使用
+- **ユースケース**: Firebase認証のように、第三者が発行したJWTを自分のサーバーで安全に検証する場合に適している（本記事の例はこちら）
+
+### JWTの検証プロセス
+
+JWTライブラリ（例: Rubyの`jwt` gem）は、トークンを検証する際に以下のステップを内部的に実行します。
+
+1. **署名の検証**:
+   - HeaderとPayloadから署名を再計算
+   - 再計算した署名と、トークンに含まれる署名が一致することを確認
+   - これにより、改ざんがないことと、正しい発行者であることが保証される
+
+2. **Payloadクレームの検証**:
+   - `exp`（有効期限）: 現在時刻が有効期限を過ぎていないか確認（**`JWT::ExpiredSignature`エラーはここで発生**）
+   - `nbf`（Not Before）: 現在時刻が、トークンが有効になる時刻を過ぎているか確認
+   - `iss`（発行者）、`aud`（対象者）: 期待される値と一致するか確認
+
+### Signatureの検証プロセス（詳細）
+
+```ruby
+# Ruby（JWT gem）での検証例
+def verify_jwt(token)
+  begin
+    # JWT.decodeは以下を自動で行う:
+    # 1. Header、Payload、Signatureを分離
+    # 2. HeaderとPayloadから署名を再計算
+    # 3. 再計算した署名と付与された署名を比較
+    # 4. Payloadのexpフィールドと現在時刻を比較
+    decoded_token = JWT.decode(token, public_key, true, { algorithm: 'RS256' })
+    puts "トークンは有効です"
+  rescue JWT::ExpiredSignature => e
+    puts "トークンが期限切れです: #{e.message}"
+  rescue JWT::DecodeError => e  
+    puts "トークンが無効です: #{e.message}"
+  end
+end
+```
+
+## Firebase tokenでの実例
+
+### Firebase tokenの特徴
+
+Firebase tokenは**1時間**で自動的に期限切れになります。これは、セキュリティを向上させるための仕組みです。
+
+```json
+{
+  "iat": 1725589984,  // 発行時刻: 2025-09-06 09:13:04
+  "exp": 1725593584   // 有効期限: 2025-09-06 10:13:04（1時間後）
+}
+```
+
+### IDトークンとリフレッシュトークンの役割分担
+
+Firebaseでは、認証時に2種類のトークンが発行されます：
+
+- **IDトークン**（JWT形式、本記事で扱っているもの）
+  - 有効期限が短い（1時間）
+  - ユーザーの認証情報を含む
+  - APIアクセス時の認証に使用
+
+- **リフレッシュトークン**
+  - 有効期限が長い（通常30日〜1年）
+  - IDトークンを再発行するためのトークン
+  - サーバーに安全に保存
+
+**フロー**: IDトークンの期限が切れたら、リフレッシュトークンを使って新しいIDトークンを取得する仕組みです。これにより、ユーザーは頻繁に再ログインする必要がありません。
+
+### 期限切れエラーが発生する流れ
+
+```
+1. ユーザーがアプリにログイン
+   ↓
+2. Firebase tokenを取得（有効期限: 1時間）
+   ↓
+3. アプリを1時間以上使用続ける
+   ↓
+4. WebViewで画面を表示しようとする
+   ↓
+5. サーバー側でtoken検証
+   ↓
+6. JWT::ExpiredSignature エラーが発生！
+```
+
+### エラーハンドリングの重要性
+
+```ruby
+# 悪い例: すべてのエラーを一律に処理
+begin
+  JWT.decode(token, public_key, true)
+rescue StandardError => e
+  raise InternalServerError  # 500エラーが発生
+end
+
+# 良い例: エラーを適切に分類
+begin
+  JWT.decode(token, public_key, true)
+rescue JWT::ExpiredSignature => e
+  # 期限切れは正常な挙動なので、適切にハンドリング
+  handle_expired_token
+rescue JWT::DecodeError => e
+  # その他の無効tokenはエラーログ出力
+  logger.error("無効なtoken: #{e.message}")
+  handle_invalid_token
+end
+```
+
+## 実開発でよくある問題と対策
+
+### 問題1: 期限切れtokenで500エラー
+
+**原因:**
+期限切れを例外的な状況として扱い、適切なエラーハンドリングをしていない。
+
+**対策:**
+```ruby
+# フォールバック戦略の実装
+def authenticate_user
+  # 1st priority: Firebase token認証
+  if firebase_token.present?
+    begin
+      user = verify_firebase_token(firebase_token)
+      return user if user
+    rescue JWT::ExpiredSignature
+      # 期限切れの場合は既存セッションにフォールバック
+      logger.info("Firebase tokenが期限切れのため、セッション認証にフォールバック")
+    rescue JWT::DecodeError => e
+      # 無効tokenの場合はログ出力
+      logger.warn("無効なFirebase token: #{e.message}")
+    end
+  end
+  
+  # 2nd priority: セッション認証
+  authenticate_by_session
+end
+```
+
+### 問題2: token更新タイミングの制御
+
+**課題:**
+tokenを更新するタイミングを適切に制御しないと、パフォーマンスの問題やエラーが発生する。
+
+**対策:**
+```ruby
+def token_needs_refresh?
+  return true if current_user.firebase_id_token.blank?
+  
+  begin
+    decoded = JWT.decode(current_user.firebase_id_token, nil, false)
+    exp_time = Time.zone.at(decoded[0]['exp'])
+    
+    # 5分前にリフレッシュ（バッファ時間を設ける）
+    exp_time <= 5.minutes.from_now
+  rescue JWT::DecodeError
+    true  # デコードできない場合はリフレッシュが必要
+  end
+end
+```
+
+### 問題3: デバッグの困難さ
+
+**JWTのデバッグツール:**
+
+1. **[jwt.io](https://jwt.io/)**
+   - JWTの内容を視覚的に確認できるWebサイト
+   - Header、Payload、Signatureを分離して表示
+
+2. **コマンドライン での確認**
+   ```bash
+   # Base64デコードでPayloadを確認
+   # 注意: macOSでは base64 -D を使用する必要がある場合があります
+   echo "eyJpc3MiOiJodHRwczov..." | base64 -d | jq .
+   ```
+
+3. **Railsコンソールでの確認**
+   ```ruby
+   # 期限切れかどうかを確認
+   token = "your_jwt_token_here"
+   decoded = JWT.decode(token, nil, false)  # 署名検証なし
+   exp_time = Time.zone.at(decoded[0]['exp'])
+   puts "有効期限: #{exp_time}"
+   puts "期限切れ: #{exp_time < Time.current}"
+   ```
+
+## まとめ
+
+### JWTの重要ポイント
+
+| 要素 | 説明 | 重要性 |
+|------|------|--------|
+| **Header** | アルゴリズム情報 | 署名方式を定義 |
+| **Payload** | 実際のデータ | ユーザー情報や有効期限を含む |
+| **Signature** | 真正性の保証 | 改ざん検知と発行者確認 |
+
+### Signature expired への対処法
+
+1. **期限切れを正常な挙動として扱う**
+2. **適切なエラーハンドリングを実装**
+3. **フォールバック戦略を用意**
+4. **token更新タイミングを最適化**
+
+### セキュリティのベストプラクティス
+
+- **短い有効期限**: 1時間程度が推奨
+- **適切なアルゴリズム**: RS256やHS256
+- **秘密鍵の管理**: 環境変数での管理
+- **HTTPSの使用**: token送信時は必須
+- **アルゴリズム明示**: 検証時にアルゴリズムを明示的に指定（`alg: none`攻撃対策）
+- **JWTの保存場所**: XSS対策でHttpOnly Cookie推奨、CSRF対策も併用
+
+JWTとSignatureの仕組みを理解することで、認証エラーの適切な対処ができるようになり、より堅牢なWebアプリケーションを構築できます。
+
+## 参考リンク
+
+- [RFC 7519 - JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
+- [JWT.io - JWT Debugger](https://jwt.io/)
+- [Firebase Authentication Documentation](https://firebase.google.com/docs/auth)
+- [Ruby JWT gem](https://github.com/jwt/ruby-jwt)


### PR DESCRIPTION
## Summary
- タイムスタンプ形式で始まるファイルをposts/ディレクトリから_posts/ディレクトリに移動しました
- ファイル構成の一貫性を保つための修正

## 移動したファイル
- `2025-09-05-react-component-conditional-rendering-best-practices.md`
- `2025-09-06-understanding-jwt-and-jwt-signature.md`

## 理由
- タイムスタンプ形式（YYYY-MM-DD-）で始まるファイルは通常`_posts/`ディレクトリに配置される
- 番号形式（0XXX_）で始まるファイルは`posts/`ディレクトリに配置される
- ファイル命名規則と配置場所の一貫性を保つため

## Test plan
- [ ] ビルドが正常に実行される
- [ ] デプロイが正常に実行される
- [ ] サイトが正常に表示される

🤖 Generated with [Claude Code](https://claude.ai/code)